### PR TITLE
Fix release PR review findings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,7 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 - Source-scoped analyzer options now merge deterministically across partial type declarations instead of depending on the first declaring file
 - Aligned invalid `external_dependency_policy` values with the documented preset-derived fallback behavior
+- Stopped nested type bodies from contributing object-creation or static-member dependencies to outer types, and now report `DCA203` for empty assembly-level `ContractScope` declarations
 
 ### Removed
 

--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -195,6 +195,8 @@ The analyzer resolves target and scope metadata using these rules:
 -   Namespace-based scope inference may add fallback scope names
     alongside assembly-level scopes when the type has no type-level
     explicit scope declarations.
+-   Empty scope names on `ContractScope`, including assembly-level
+    declarations, report `DCA203`.
 -   In `external_dependency_policy = metadata` mode, namespace-based
     inference remains limited to current-compilation types; referenced
     assemblies contribute explicit metadata and implication edges only.

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -439,6 +439,8 @@ Provided contracts are expanded through the transitive implication closure befor
 
 Assembly-level scopes always apply to types in the declaring assembly. Type-level scope declarations add to those assembly-level scopes. Namespace-based scope inference contributes additional scope names only when the type has no explicit scope declarations.
 
+Empty scope names on `ContractScope`, including assembly-level declarations, report `DCA203` and do not contribute resolved scope names.
+
 When `dependency_contract_analyzer.external_dependency_policy = metadata`, the analyzer also reads explicit provided contracts, targets, scopes, and implication edges from referenced assemblies for dependency matching. Local and referenced implication graphs are applied together until contract expansion reaches a fixed point. Referenced assemblies do not contribute namespace-inferred names, referenced implication diagnostics are not reported in the consuming compilation, and undeclared target/scope validation remains current-compilation-only.
 
 ## 8. Diagnostics
@@ -453,7 +455,7 @@ When `dependency_contract_analyzer.external_dependency_policy = metadata`, the a
 | `DCA200` | `Warning` | Required target is undeclared in the compilation |
 | `DCA201` | `Warning` | Required scope is undeclared in the compilation |
 | `DCA202` | `Warning` | Contract implication definition is cyclic |
-| `DCA203` | `Warning` | Scope name is empty |
+| `DCA203` | `Warning` | Scope name is empty, including assembly-level `ContractScope` declarations |
 | `DCA204` | `Warning` | Target name is empty |
 | `DCA205` | `Info` | Required target is not used by any analyzable dependency |
 | `DCA206` | `Info` | Required scope is not used by any analyzable dependency |

--- a/src/DependencyContractAnalyzer/Analyzers/DependencyContractAnalyzer.cs
+++ b/src/DependencyContractAnalyzer/Analyzers/DependencyContractAnalyzer.cs
@@ -113,13 +113,22 @@ public sealed class DependencyContractAnalyzerDiagnosticAnalyzer : DiagnosticAna
             var knownScopes = contractScopeAttributeSymbol is null
                 ? CreateEmptyNameSet()
                 : CollectKnownScopes(startContext.Compilation.Assembly, contractScopeAttributeSymbol, namespaceInferenceOptions);
+            var assemblyScopeDiagnostics = contractScopeAttributeSymbol is null
+                ? ImmutableArray<Diagnostic>.Empty
+                : CollectAssemblyScopeDiagnostics(startContext.Compilation.Assembly, contractScopeAttributeSymbol);
 
-            if (!contractImplicationResolver.Diagnostics.IsDefaultOrEmpty)
+            if (!contractImplicationResolver.Diagnostics.IsDefaultOrEmpty ||
+                !assemblyScopeDiagnostics.IsDefaultOrEmpty)
             {
                 startContext.RegisterCompilationEndAction(
                     compilationContext =>
                     {
                         foreach (var diagnostic in contractImplicationResolver.Diagnostics)
+                        {
+                            compilationContext.ReportDiagnostic(diagnostic);
+                        }
+
+                        foreach (var diagnostic in assemblyScopeDiagnostics)
                         {
                             compilationContext.ReportDiagnostic(diagnostic);
                         }
@@ -258,6 +267,38 @@ public sealed class DependencyContractAnalyzerDiagnosticAnalyzer : DiagnosticAna
                     DiagnosticDescriptors.EmptyScopeName,
                     GetAttributeLocation(attribute, namedType)));
         }
+    }
+
+    private static ImmutableArray<Diagnostic> CollectAssemblyScopeDiagnostics(
+        IAssemblySymbol assembly,
+        INamedTypeSymbol contractScopeAttributeSymbol)
+    {
+        var diagnostics = ImmutableArray.CreateBuilder<Diagnostic>();
+
+        foreach (var attribute in assembly.GetAttributes())
+        {
+            if (!attribute.AttributeClass.SymbolEquals(contractScopeAttributeSymbol))
+            {
+                continue;
+            }
+
+            if (!TryGetStringArgument(attribute, 0, out var scopeName))
+            {
+                continue;
+            }
+
+            if (ContractNameNormalizer.Normalize(scopeName) is not null)
+            {
+                continue;
+            }
+
+            diagnostics.Add(
+                Diagnostic.Create(
+                    DiagnosticDescriptors.EmptyScopeName,
+                    GetAttributeLocation(attribute, assembly)));
+        }
+
+        return diagnostics.ToImmutable();
     }
 
     private static void AnalyzeDeclaredTargets(

--- a/src/DependencyContractAnalyzer/Helpers/DependencyCollector.cs
+++ b/src/DependencyContractAnalyzer/Helpers/DependencyCollector.cs
@@ -37,6 +37,11 @@ internal static class DependencyCollector
 
         foreach (var member in type.GetMembers())
         {
+            if (!SupportsSyntaxDependencyCollection(member))
+            {
+                continue;
+            }
+
             if (HasExcludedDependencySource(member, excludeDependencyContractSourceAttributeSymbol))
             {
                 continue;
@@ -122,6 +127,9 @@ internal static class DependencyCollector
     private static bool IsMethodDependencyCandidate(IMethodSymbol method) =>
         !method.IsImplicitlyDeclared &&
         method.MethodKind is MethodKind.Ordinary or MethodKind.ExplicitInterfaceImplementation;
+
+    private static bool SupportsSyntaxDependencyCollection(ISymbol member) =>
+        member is IMethodSymbol or IPropertySymbol or IFieldSymbol or IEventSymbol;
 
     private static bool HasExcludedDependencySource(
         ISymbol member,

--- a/tests/DependencyContractAnalyzer.Tests/DependencyContractAnalyzerTests.cs
+++ b/tests/DependencyContractAnalyzer.Tests/DependencyContractAnalyzerTests.cs
@@ -1596,6 +1596,37 @@ public sealed class DependencyContractAnalyzerTests
     }
 
     [Fact]
+    public async Task DoesNotTreatNestedTypeObjectCreationAsOuterTypeDependency()
+    {
+        const string source = """
+            using DependencyContractAnalyzer;
+
+            [ProvidesContract("thread-safe")]
+            public sealed class Foo
+            {
+            }
+
+            [{|#0:RequiresDependencyContract(typeof(Foo), "thread-safe")|}]
+            public sealed class Consumer
+            {
+                public sealed class NestedHelper
+                {
+                    public Foo Create()
+                    {
+                        return new Foo();
+                    }
+                }
+            }
+            """;
+
+        await DependencyContractAnalyzerVerifier.VerifyAnalyzerAsync(
+            source,
+            DependencyContractAnalyzerVerifier.Diagnostic(DiagnosticIds.UnusedRequiredDependencyType)
+                .WithLocation(0)
+                .WithArguments("Foo"));
+    }
+
+    [Fact]
     public async Task ReportsNoDiagnosticWhenTargetedCreatedTypeProvidesRequiredContract()
     {
         const string source = """
@@ -1727,6 +1758,35 @@ public sealed class DependencyContractAnalyzerTests
         Assert.Equal(DiagnosticIds.UnusedRequiredDependencyType, diagnostic.Id);
         Assert.Equal(DiagnosticSeverity.Warning, diagnostic.Severity);
         Assert.Contains("Clock", diagnostic.GetMessage());
+    }
+
+    [Fact]
+    public async Task DoesNotTreatNestedTypeStaticUsageAsOuterTypeDependency()
+    {
+        const string source = """
+            using DependencyContractAnalyzer;
+
+            [ProvidesContract("thread-safe")]
+            public static class Clock
+            {
+                public static int UtcHour => 12;
+            }
+
+            [{|#0:RequiresDependencyContract(typeof(Clock), "thread-safe")|}]
+            public sealed class Consumer
+            {
+                public sealed class NestedHelper
+                {
+                    public int Read() => Clock.UtcHour;
+                }
+            }
+            """;
+
+        await DependencyContractAnalyzerVerifier.VerifyAnalyzerAsync(
+            source,
+            DependencyContractAnalyzerVerifier.Diagnostic(DiagnosticIds.UnusedRequiredDependencyType)
+                .WithLocation(0)
+                .WithArguments("Clock"));
     }
 
     [Fact]
@@ -2628,6 +2688,24 @@ public sealed class DependencyContractAnalyzerTests
             source,
             DependencyContractAnalyzerVerifier.Diagnostic(DiagnosticIds.EmptyScopeName).WithLocation(0),
             DependencyContractAnalyzerVerifier.Diagnostic(DiagnosticIds.EmptyContractName).WithLocation(1));
+    }
+
+    [Fact]
+    public async Task ReportsDiagnosticWhenAssemblyLevelScopeNameIsEmpty()
+    {
+        const string source = """
+            using DependencyContractAnalyzer;
+
+            [assembly: {|#0:ContractScope("   ")|}]
+
+            public sealed class Marker
+            {
+            }
+            """;
+
+        await DependencyContractAnalyzerVerifier.VerifyAnalyzerAsync(
+            source,
+            DependencyContractAnalyzerVerifier.Diagnostic(DiagnosticIds.EmptyScopeName).WithLocation(0));
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
Address review findings from the release PR.

## Included
- exclude nested type declarations from syntax-based dependency collection so outer types do not inherit object-creation or static-member dependencies from nested helper types
- report `DCA203` for empty assembly-level `ContractScope` declarations
- add regression tests for both fixes
- clarify the specification text for assembly-level empty-scope handling

## Validation
- `dotnet test DependencyContractAnalyzer.slnx -c Release --no-restore`
