### PR TITLE
Use NUGET_USER secret in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,7 @@ jobs:
   publish:
     runs-on: windows-latest
     env:
-      NUGET_USER: ${{ vars.NUGET_USER }}
+      NUGET_USER: ${{ secrets.NUGET_USER }}
 
     steps:
       - name: Checkout
@@ -71,7 +71,7 @@ jobs:
           $publishTarget = "${{ steps.publish_target.outputs.publish_target_name }}"
 
           if ([string]::IsNullOrWhiteSpace($env:NUGET_USER)) {
-            throw "Repository variable NUGET_USER must be configured before publishing to $publishTarget."
+            throw "Repository secret NUGET_USER must be configured before publishing to $publishTarget."
           }
 
       - name: Validate release tag format

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,7 +71,7 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 - Kept the runnable sample project warning-free by moving representative invalid cases into sample documentation snippets
 - Expanded public attribute XML documentation to explain normalization, implication, exclusion, and exact-match suppression behavior
 - Clarified current design boundaries for hierarchy semantics, `.editorconfig`, namespace inference, suppression, and `DCA101` naming scope
-- Simplified Trusted Publishing configuration to use a single `NUGET_USER` setting for both nuget.org and `int.nugettest.org`
+- Simplified Trusted Publishing configuration to use a single `NUGET_USER` secret for both nuget.org and `int.nugettest.org`
 - Clarified the large regression suite with section comments and targeted notes for tricky metadata/preset/inference cases
 - Consolidated duplicated analyzer-config helper logic and test-verifier compilation setup into shared implementations
 - Consolidated duplicated test attribute-source fixtures into a shared helper for verifier and external-metadata tests

--- a/docs/trusted-publishing.ja.md
+++ b/docs/trusted-publishing.ja.md
@@ -14,7 +14,7 @@
 4. `develop` publish を有効にする場合は、この GitHub リポジトリを `int.nugettest.org` 側パッケージの Trusted Publisher としても登録します。
 5. nuget.org の Trusted Publishing policy には workflow file 名として `publish.yml` を登録します。`.github/workflows/` のパスは付けません。
 6. `develop` publish を有効にする場合は、`int.nugettest.org` 側の Trusted Publishing policy にも同じ `publish.yml` を登録します。
-7. nuget.org と `int.nugettest.org` の両方で publish 可能なアカウント名を repository variable `NUGET_USER` に設定します。
+7. nuget.org と `int.nugettest.org` の両方で publish 可能なアカウント名を repository secret `NUGET_USER` に設定します。
 9. publish ワークフローで `permissions.id-token: write` を維持します。
 10. annotated tag として `v<major>.<minor>.<patch>` 形式の release tag を
    作成して push します。例: `v0.1.0`
@@ -27,7 +27,7 @@
 - publish 時の認証は `NuGet/login@v1` を利用します。
 - OIDC を使える場合、長期 API キーをリポジトリ secret に置かないでください。
 - push 前に build、test、pack を完了させてください。
-- publish workflow は単一の repository variable `NUGET_USER` を参照し、nuget.org と `int.nugettest.org` の両方で同じ publish アカウント名を使います。
+- publish workflow は単一の repository secret `NUGET_USER` を参照し、nuget.org と `int.nugettest.org` の両方で同じ publish アカウント名を使います。
 - manual の `workflow_dispatch` 実行は `develop` と `main` でのみ許可します。
 - `develop` からの manual 実行は `https://int.nugettest.org/api/v2/package` へ publish します。
 - `main` からの manual 実行は検証専用で、

--- a/docs/trusted-publishing.md
+++ b/docs/trusted-publishing.md
@@ -14,7 +14,7 @@ Use NuGet Trusted Publishing with GitHub Actions and OpenID Connect instead of l
 4. Add this GitHub repository as a Trusted Publisher for the `int.nugettest.org` package if `develop` publishes are enabled.
 5. Register the `publish.yml` workflow file in the nuget.org Trusted Publishing policy. Use the workflow file name only: `publish.yml`.
 6. Register the same `publish.yml` workflow file in the `int.nugettest.org` Trusted Publishing policy if `develop` publishes are enabled.
-7. Configure the repository variable `NUGET_USER` with the account name that is allowed to publish the package on both nuget.org and `int.nugettest.org`.
+7. Configure the repository secret `NUGET_USER` with the account name that is allowed to publish the package on both nuget.org and `int.nugettest.org`.
 9. Ensure the publish workflow keeps `permissions.id-token: write`.
 10. Create and push an annotated release tag using the format
    `v<major>.<minor>.<patch>`, such as `v0.1.0`.
@@ -27,7 +27,7 @@ Use NuGet Trusted Publishing with GitHub Actions and OpenID Connect instead of l
 - The publish workflow authenticates using `NuGet/login@v1`.
 - Avoid storing long-lived API keys in repository secrets when OIDC can be used.
 - Build, test, and pack should run before pushing packages.
-- The publish workflow expects a single repository variable `NUGET_USER`, and it uses the same publishing account name for both nuget.org and `int.nugettest.org`.
+- The publish workflow expects a single repository secret `NUGET_USER`, and it uses the same publishing account name for both nuget.org and `int.nugettest.org`.
 - Manual `workflow_dispatch` runs are allowed only on `develop` and `main`.
 - Manual runs from `develop` publish packages to `https://int.nugettest.org/api/v2/package`.
 - Manual runs from `main` are validation-only, may build/test/pack/upload artifacts, and do not publish packages.


### PR DESCRIPTION
## Summary\n- switch the publish workflow from ars.NUGET_USER to secrets.NUGET_USER\n- update trusted publishing documentation to require a repository secret\n- keep the single-account model for nuget.org and int.nugettest.org\n\n## Verification\n- dotnet test DependencyContractAnalyzer.slnx -c Release --no-restore\n- git diff --check\n\nCloses #98