### PR TITLE
Route publishes by branch

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,25 +34,71 @@ jobs:
         id: publish_target
         shell: pwsh
         run: |
-          if ($env:GITHUB_EVENT_NAME -eq 'push') {
-            "should_publish=true" >> $env:GITHUB_OUTPUT
-            "publish_target_name=nuget.org" >> $env:GITHUB_OUTPUT
-            "token_service_url=https://www.nuget.org/api/v2/token" >> $env:GITHUB_OUTPUT
-            "audience=https://www.nuget.org" >> $env:GITHUB_OUTPUT
-            "package_source=https://www.nuget.org/api/v2/package" >> $env:GITHUB_OUTPUT
-          } elseif ($env:GITHUB_REF_NAME -eq 'develop') {
-            "should_publish=true" >> $env:GITHUB_OUTPUT
-            "publish_target_name=int.nugettest.org" >> $env:GITHUB_OUTPUT
-            "token_service_url=https://int.nugettest.org/api/v2/token" >> $env:GITHUB_OUTPUT
-            "audience=https://int.nugettest.org" >> $env:GITHUB_OUTPUT
-            "package_source=https://int.nugettest.org/api/v2/package" >> $env:GITHUB_OUTPUT
-          } else {
-            "should_publish=false" >> $env:GITHUB_OUTPUT
-            "publish_target_name=validation-only" >> $env:GITHUB_OUTPUT
-            "token_service_url=" >> $env:GITHUB_OUTPUT
-            "audience=" >> $env:GITHUB_OUTPUT
-            "package_source=" >> $env:GITHUB_OUTPUT
+          function Set-PublishTarget([string]$branchName) {
+            switch ($branchName) {
+              'main' {
+                "should_publish=true" >> $env:GITHUB_OUTPUT
+                "publish_branch=main" >> $env:GITHUB_OUTPUT
+                "publish_target_name=nuget.org" >> $env:GITHUB_OUTPUT
+                "token_service_url=https://www.nuget.org/api/v2/token" >> $env:GITHUB_OUTPUT
+                "audience=https://www.nuget.org" >> $env:GITHUB_OUTPUT
+                "package_source=https://www.nuget.org/api/v2/package" >> $env:GITHUB_OUTPUT
+              }
+              'develop' {
+                "should_publish=true" >> $env:GITHUB_OUTPUT
+                "publish_branch=develop" >> $env:GITHUB_OUTPUT
+                "publish_target_name=int.nugettest.org" >> $env:GITHUB_OUTPUT
+                "token_service_url=https://int.nugettest.org/api/v2/token" >> $env:GITHUB_OUTPUT
+                "audience=https://int.nugettest.org" >> $env:GITHUB_OUTPUT
+                "package_source=https://int.nugettest.org/api/v2/package" >> $env:GITHUB_OUTPUT
+              }
+              default {
+                throw "Publishing is allowed only from main or develop."
+              }
+            }
           }
+
+          function Test-CommitReachableFrom([string]$remoteBranch) {
+            git merge-base --is-ancestor HEAD $remoteBranch
+            if ($LASTEXITCODE -eq 0) {
+              return $true
+            }
+
+            if ($LASTEXITCODE -eq 1) {
+              return $false
+            }
+
+            throw "Failed to evaluate whether HEAD is reachable from $remoteBranch."
+          }
+
+          if ($env:GITHUB_EVENT_NAME -eq 'workflow_dispatch') {
+            Set-PublishTarget $env:GITHUB_REF_NAME
+            exit 0
+          }
+
+          git fetch origin refs/heads/main:refs/remotes/origin/main refs/heads/develop:refs/remotes/origin/develop
+          if ($LASTEXITCODE -ne 0) {
+            throw "Failed to fetch publish branches."
+          }
+
+          $isOnMain = Test-CommitReachableFrom 'origin/main'
+          $isOnDevelop = Test-CommitReachableFrom 'origin/develop'
+
+          if ($isOnMain -and -not $isOnDevelop) {
+            Set-PublishTarget 'main'
+            exit 0
+          }
+
+          if ($isOnDevelop -and -not $isOnMain) {
+            Set-PublishTarget 'develop'
+            exit 0
+          }
+
+          if ($isOnMain -and $isOnDevelop) {
+            throw "Tagged commit is reachable from both main and develop. Tag publishes must target a commit that belongs to exactly one publish branch."
+          }
+
+          throw "Tagged commit is not reachable from main or develop."
 
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@v5
@@ -102,18 +148,12 @@ jobs:
             throw "Release tags must be annotated tags."
           }
 
-      - name: Validate tag commit is on main
+      - name: Validate tag publish branch was resolved
         if: github.event_name == 'push'
         shell: pwsh
         run: |
-          git fetch origin main --depth=1
-          if ($LASTEXITCODE -ne 0) {
-            throw "Failed to fetch origin/main."
-          }
-
-          git merge-base --is-ancestor HEAD origin/main
-          if ($LASTEXITCODE -ne 0) {
-            throw "Release tags must point to commits already merged into main."
+          if ([string]::IsNullOrWhiteSpace("${{ steps.publish_target.outputs.publish_branch }}")) {
+            throw "Failed to resolve publish branch for the tagged commit."
           }
 
       - name: Restore

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -138,16 +138,20 @@ Releases must use a Pull Request from `develop` into `main`.
 -   feature and bug-fix Pull Requests into `develop` use squash merges
 -   release tags must be annotated tags using the format
     `v<major>.<minor>.<patch>`
--   release tags must be created only from commits already merged into
-    `main`
--   release publishes to `nuget.org` must originate from `main` tags
+-   release tags may target commits reachable from `main` or `develop`
+    only
+-   tag publishes from `main` route to `nuget.org`
+-   tag publishes from `develop` route to `https://int.nugettest.org/`
+-   tag publishes fail when the tagged commit is reachable from both
+    `main` and `develop`, or from neither branch
 -   GitHub Releases are created from release tags on `main`
 -   manual publish workflow dispatches may run only for `develop` and
     `main`
 -   manual dispatches from `develop` publish to
     `https://int.nugettest.org/`
--   manual dispatches from `main` are validation-only and do not publish
--   publish workflow validation enforces annotated release tags
+-   manual dispatches from `main` publish to `https://www.nuget.org/`
+-   publish workflow validation enforces annotated release tags and
+    branch-based feed routing
 
 The required CI status checks for the split workflow are `build`,
 `test`, `analyzer`, and `pack`. Repository settings must be updated to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 ## [Unreleased]
 
+## Breaking Changes
+
+- Publish destination is now branch-based: `main` always publishes to nuget.org, `develop` always publishes to `int.nugettest.org`, and ambiguous tag commits fail validation instead of defaulting to a feed.
+
 ### Added
 
 - OSS documentation foundation for the `DependencyContractAnalyzer` repository
@@ -72,6 +76,7 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 - Expanded public attribute XML documentation to explain normalization, implication, exclusion, and exact-match suppression behavior
 - Clarified current design boundaries for hierarchy semantics, `.editorconfig`, namespace inference, suppression, and `DCA101` naming scope
 - Simplified Trusted Publishing configuration to use a single `NUGET_USER` secret for both nuget.org and `int.nugettest.org`
+- Switched publish routing to branch-based feed selection so `main` always targets nuget.org and `develop` always targets `int.nugettest.org`, regardless of trigger type
 - Clarified the large regression suite with section comments and targeted notes for tricky metadata/preset/inference cases
 - Consolidated duplicated analyzer-config helper logic and test-verifier compilation setup into shared implementations
 - Consolidated duplicated test attribute-source fixtures into a shared helper for verifier and external-metadata tests

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -674,6 +674,59 @@ This decision adds no new diagnostics or configuration keys.
 
 ------------------------------------------------------------------------
 
+## ADR-012 Publish feed routing is branch-based rather than trigger-based
+
+Status: Accepted
+Specification: Updated
+
+### Context
+
+The repository already supported publishing through both annotated tag
+pushes and manual `workflow_dispatch` runs. However, the publish target
+had been selected partly by trigger type, which allowed tag pushes to
+default to `nuget.org` even when the tagged commit belonged to
+`develop`.
+
+The required release policy is stricter: every publish from `develop`
+must go only to `int.nugettest.org`, and every publish from `main` must
+go only to `nuget.org`, regardless of how publishing is triggered.
+
+### Decision
+
+Publish destination is determined by branch, not by trigger type.
+Manual dispatches from `develop` publish only to
+`int.nugettest.org`. Manual dispatches from `main` publish only to
+`nuget.org`.
+
+Tag-push publishes resolve their destination by tagged-commit branch
+containment. A tagged commit reachable only from `main` publishes only
+to `nuget.org`. A tagged commit reachable only from `develop` publishes
+only to `int.nugettest.org`.
+
+If a tagged commit is reachable from both `main` and `develop`, or from
+neither branch, the workflow fails validation instead of guessing.
+
+GitHub Releases remain `main`-only release artifacts.
+
+### Consequences
+
+-   feed routing now enforces the repository's branch roles across both
+    manual and tag-based publishing
+-   accidental cross-publishing from `develop` to `nuget.org`, or from
+    `main` to `int.nugettest.org`, is blocked by validation
+-   tag publishes now require branch topology to be unambiguous; shared
+    commits must not be tagged for publishing unless the ambiguity is
+    resolved first
+
+### Related
+
+-   Issue: #100
+-   Pull Request:
+-   Specification reference: `AGENTS.md`, `docs/trusted-publishing.md`
+-   Related decisions:
+
+------------------------------------------------------------------------
+
 # Maintenance Rules
 
 -   Each decision should be concise.

--- a/docs/trusted-publishing.ja.md
+++ b/docs/trusted-publishing.ja.md
@@ -30,18 +30,17 @@
 - publish workflow は単一の repository secret `NUGET_USER` を参照し、nuget.org と `int.nugettest.org` の両方で同じ publish アカウント名を使います。
 - manual の `workflow_dispatch` 実行は `develop` と `main` でのみ許可します。
 - `develop` からの manual 実行は `https://int.nugettest.org/api/v2/package` へ publish します。
-- `main` からの manual 実行は検証専用で、
-  build/test/pack/artifact upload のみを行い、パッケージ publish は行いません。
-- publish 対象の release tag は `main` にマージ済みの commit を指している必要があります。
+- `main` からの manual 実行は `https://www.nuget.org/api/v2/package` へ publish します。
 - publish workflow は release tag が annotated tag であることを検証します。
-- annotated release tag の push は `https://www.nuget.org/api/v2/package` へ publish します。
+- tag push の publish 先は trigger 種別ではなく branch により決まり、`main` の tag は `https://www.nuget.org/api/v2/package`、`develop` の tag は `https://int.nugettest.org/api/v2/package` に publish します。
+- tag 対象 commit が `main` と `develop` の両方から到達可能、またはどちらからも到達不可能な場合は publish を失敗させます。
 - GitHub Release は `main` 上の release tag から作成します。
 - リリースノートは `CHANGELOG.md` と整合させてください。
 
 ## ブランチ運用
 
 - `main`: default branch 兼 `nuget.org` 向け安定版 release branch
-- `develop`: integration branch 兼 `int.nugettest.org` 向け manual publish branch
+- `develop`: integration branch 兼 `int.nugettest.org` 向け publish branch
 
 ## Release チェックリスト
 
@@ -54,4 +53,5 @@
 - breaking-change issue を確認済み
 - release Pull Request を `main` にマージ済み
 - stable version を確認済み
-- annotated tag を `main` から作成済み
+- publish 先に対応する branch を確認済み
+- annotated tag を intended publish branch から作成済み

--- a/docs/trusted-publishing.md
+++ b/docs/trusted-publishing.md
@@ -30,17 +30,17 @@ Use NuGet Trusted Publishing with GitHub Actions and OpenID Connect instead of l
 - The publish workflow expects a single repository secret `NUGET_USER`, and it uses the same publishing account name for both nuget.org and `int.nugettest.org`.
 - Manual `workflow_dispatch` runs are allowed only on `develop` and `main`.
 - Manual runs from `develop` publish packages to `https://int.nugettest.org/api/v2/package`.
-- Manual runs from `main` are validation-only, may build/test/pack/upload artifacts, and do not publish packages.
-- Published release tags must point to commits already merged into `main`.
+- Manual runs from `main` publish packages to `https://www.nuget.org/api/v2/package`.
 - The publish workflow validates that release tags are annotated tags.
-- Pushes of annotated release tags publish packages to `https://www.nuget.org/api/v2/package`.
+- Tag pushes publish by branch instead of by trigger type: `main` tags publish to `https://www.nuget.org/api/v2/package`, and `develop` tags publish to `https://int.nugettest.org/api/v2/package`.
+- Tag pushes fail when the tagged commit is reachable from both `main` and `develop`, or from neither branch.
 - GitHub Releases should be created from release tags on `main`.
 - Release notes should reference `CHANGELOG.md`.
 
 ## Branching model
 
 - `main`: default branch and stable release branch for `nuget.org` publishing
-- `develop`: integration branch and `int.nugettest.org` manual publish branch
+- `develop`: integration branch and `int.nugettest.org` publish branch
 
 ## Release checklist
 
@@ -53,4 +53,5 @@ Use NuGet Trusted Publishing with GitHub Actions and OpenID Connect instead of l
 - breaking-change issues reviewed
 - release Pull Request merged into `main`
 - stable version confirmed
-- annotated tag created from `main`
+- publish target branch confirmed (`main` for nuget.org or `develop` for `int.nugettest.org`)
+- annotated tag created from the intended publish branch


### PR DESCRIPTION
## Summary\n- route all publishes by branch instead of trigger type\n- send all develop publishes to int.nugettest.org and all main publishes to 
uget.org\n- fail tag-push validation when the tagged commit is reachable from both publish branches or from neither branch\n- update governance and trusted publishing documentation to match the new policy\n\n## Verification\n- dotnet test DependencyContractAnalyzer.slnx -c Release --no-restore\n- git diff --check\n\nCloses #100