### PR TITLE
Fix tag metadata fetch in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -134,7 +134,7 @@ jobs:
         run: |
           $tagRef = "refs/tags/$env:GITHUB_REF_NAME"
 
-          git fetch origin "$tagRef:$tagRef" --force
+          git fetch origin "${tagRef}:$tagRef" --force
           if ($LASTEXITCODE -ne 0) {
             throw "Failed to fetch release tag metadata."
           }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,7 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 - Source-scoped analyzer options now merge deterministically across partial type declarations instead of depending on the first declaring file
 - Aligned invalid `external_dependency_policy` values with the documented preset-derived fallback behavior
 - Stopped nested type bodies from contributing object-creation or static-member dependencies to outer types, and now report `DCA203` for empty assembly-level `ContractScope` declarations
+- Fixed the publish workflow's annotated-tag validation step so PowerShell parses the tag refspec correctly before fetching tag metadata
 
 ### Removed
 


### PR DESCRIPTION
## Summary
- fix the PowerShell refspec interpolation used by annotated tag validation in publish.yml
- keep publish behavior unchanged while preventing the parser error raised by the old tag refspec string
- record the workflow bugfix in CHANGELOG.md
## Verification
- pwsh -NoProfile -Command ' = ''refs/tags/v0.1.0''; Write-Output ":"'
- dotnet test DependencyContractAnalyzer.slnx -c Release --no-restore
- git diff --check