### PR TITLE
Stabilize tagged publish versions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -72,9 +72,12 @@ jobs:
           }
 
           if ($env:GITHUB_EVENT_NAME -eq 'workflow_dispatch') {
+            "expected_package_version=" >> $env:GITHUB_OUTPUT
             Set-PublishTarget $env:GITHUB_REF_NAME
             exit 0
           }
+
+          "expected_package_version=$($env:GITHUB_REF_NAME.Substring(1))" >> $env:GITHUB_OUTPUT
 
           git fetch origin refs/heads/main:refs/remotes/origin/main refs/heads/develop:refs/remotes/origin/develop
           if ($LASTEXITCODE -ne 0) {
@@ -166,7 +169,18 @@ jobs:
         run: dotnet test DependencyContractAnalyzer.slnx -c Release --no-build
 
       - name: Pack
-        run: dotnet pack src/DependencyContractAnalyzer/DependencyContractAnalyzer.csproj -c Release --no-build -o artifacts
+        run: dotnet pack src/DependencyContractAnalyzer/DependencyContractAnalyzer.csproj -c Release --no-build -p:RelaxVersionerCheckWorkingDirectoryStatus=false -o artifacts
+
+      - name: Verify package version resolved from release tag
+        if: github.event_name == 'push'
+        shell: pwsh
+        run: |
+          $expectedVersion = "${{ steps.publish_target.outputs.expected_package_version }}"
+          $expectedPackagePath = "artifacts/DependencyContractAnalyzer.$expectedVersion.nupkg"
+
+          if (-not (Test-Path $expectedPackagePath)) {
+            throw "Expected tagged package not found: $expectedPackagePath"
+          }
 
       - name: Upload packages
         uses: actions/upload-artifact@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,7 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 - Aligned invalid `external_dependency_policy` values with the documented preset-derived fallback behavior
 - Stopped nested type bodies from contributing object-creation or static-member dependencies to outer types, and now report `DCA203` for empty assembly-level `ContractScope` declarations
 - Fixed the publish workflow's annotated-tag validation step so PowerShell parses the tag refspec correctly before fetching tag metadata
+- Fixed the publish workflow so tagged publishes keep the exact tag version instead of incrementing because of generated build outputs
 
 ### Removed
 

--- a/docs/trusted-publishing.ja.md
+++ b/docs/trusted-publishing.ja.md
@@ -34,6 +34,8 @@
 - publish workflow は release tag が annotated tag であることを検証します。
 - tag push の publish 先は trigger 種別ではなく branch により決まり、`main` の tag は `https://www.nuget.org/api/v2/package`、`develop` の tag は `https://int.nugettest.org/api/v2/package` に publish します。
 - tag 対象 commit が `main` と `develop` の両方から到達可能、またはどちらからも到達不可能な場合は publish を失敗させます。
+- publish 時の pack step では、生成された build output によって package version が勝手に繰り上がらないように、RelaxVersioner の working-directory dirty check を無効化します。
+- tag push では upload 前に、生成された `.nupkg` のファイル名が release tag の version と一致することを検証します。
 - GitHub Release は `main` 上の release tag から作成します。
 - リリースノートは `CHANGELOG.md` と整合させてください。
 

--- a/docs/trusted-publishing.md
+++ b/docs/trusted-publishing.md
@@ -34,6 +34,8 @@ Use NuGet Trusted Publishing with GitHub Actions and OpenID Connect instead of l
 - The publish workflow validates that release tags are annotated tags.
 - Tag pushes publish by branch instead of by trigger type: `main` tags publish to `https://www.nuget.org/api/v2/package`, and `develop` tags publish to `https://int.nugettest.org/api/v2/package`.
 - Tag pushes fail when the tagged commit is reachable from both `main` and `develop`, or from neither branch.
+- The publish-time pack step disables RelaxVersioner's working-directory dirty check so generated build outputs do not silently bump the package version.
+- Tag pushes verify that the generated `.nupkg` filename matches the release tag version before upload.
 - GitHub Releases should be created from release tags on `main`.
 - Release notes should reference `CHANGELOG.md`.
 


### PR DESCRIPTION
## Summary
- disable RelaxVersioner working-directory dirty checks for the publish-time pack step
- verify that tag pushes produce a package whose filename matches the release tag version before upload
- document the version-stability behavior in the trusted publishing guides
## Verification
- dotnet test DependencyContractAnalyzer.slnx -c Release --no-restore
- dotnet pack src/DependencyContractAnalyzer/DependencyContractAnalyzer.csproj -c Release --no-build -p:RelaxVersionerCheckWorkingDirectoryStatus=false -o artifacts/tag-version-check
- confirmed local pack output DependencyContractAnalyzer.0.0.1.nupkg from tag 0.0.1
- git diff --check
Closes #104