### PR TITLE
Use absolute icon URLs in READMEs

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="assets/package-icon.png" alt="DependencyContractAnalyzer icon" width="160" />
+  <img src="https://raw.githubusercontent.com/iwizsophy/dependency-contract-analyzer/50c87dfcfea9a5f9e0fd59e2392ee7bfb07ea6bd/assets/package-icon.png" alt="DependencyContractAnalyzer icon" width="160" />
 </p>
 
 # DependencyContractAnalyzer

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="assets/package-icon.png" alt="DependencyContractAnalyzer icon" width="160" />
+  <img src="https://raw.githubusercontent.com/iwizsophy/dependency-contract-analyzer/50c87dfcfea9a5f9e0fd59e2392ee7bfb07ea6bd/assets/package-icon.png" alt="DependencyContractAnalyzer icon" width="160" />
 </p>
 
 # DependencyContractAnalyzer


### PR DESCRIPTION
## Summary\n- replace the relative README icon path with an absolute raw.githubusercontent.com URL\n- pin the image URL to a commit that already contains the packaged icon asset\n- keep README.md and README.ja.md aligned\n\n## Verification\n- Invoke-WebRequest -Uri https://raw.githubusercontent.com/iwizsophy/dependency-contract-analyzer/50c87dfcfea9a5f9e0fd59e2392ee7bfb07ea6bd/assets/package-icon.png -Method Head\n- git diff --check\n\nThis makes the icon render in NuGet package README pages, where relative image paths are not supported.