### PR TITLE
Strengthen analyzer tests across current .NET hosts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
         run: dotnet restore DependencyContractAnalyzer.slnx
 
       - name: Build
-        run: dotnet build DependencyContractAnalyzer.slnx -c Release --no-restore
+        run: dotnet build DependencyContractAnalyzer.slnx -c Release --no-restore -m:1
 
   test:
     runs-on: windows-latest
@@ -47,7 +47,10 @@ jobs:
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: ${{ env.DOTNET_VERSION }}
+          dotnet-version: |
+            8.0.x
+            9.0.x
+            ${{ env.DOTNET_VERSION }}
           cache: true
           cache-dependency-path: |
             Directory.Build.props
@@ -59,7 +62,7 @@ jobs:
         run: dotnet restore DependencyContractAnalyzer.slnx
 
       - name: Test
-        run: dotnet test DependencyContractAnalyzer.slnx -c Release --no-restore --collect "XPlat Code Coverage" --results-directory artifacts/test-results
+        run: dotnet test DependencyContractAnalyzer.slnx -c Release --no-restore --collect "XPlat Code Coverage" --results-directory artifacts/test-results -m:1
 
       - name: Upload test results
         uses: actions/upload-artifact@v7
@@ -90,7 +93,7 @@ jobs:
         run: dotnet restore DependencyContractAnalyzer.slnx
 
       - name: Analyzer quality gate
-        run: dotnet build DependencyContractAnalyzer.slnx -c Release --no-restore -warnaserror
+        run: dotnet build DependencyContractAnalyzer.slnx -c Release --no-restore -warnaserror -m:1
 
   pack:
     runs-on: windows-latest

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -727,6 +727,57 @@ GitHub Releases remain `main`-only release artifacts.
 
 ------------------------------------------------------------------------
 
+## ADR-013 Analyzer tests use explicit current-host reference assemblies
+
+Status: Accepted
+Specification: Pending update
+
+### Context
+
+The repository's analyzer tests had been running under a `net10.0`
+test host while still relying on implicit reference-assembly selection
+in `Microsoft.CodeAnalysis.Testing` and on runtime-provided platform
+assemblies for hand-built compilations. That made the test harness
+sensitive to host-environment drift and allowed dependency updates such
+as `coverlet.collector 8.0.0` to break the suite through reference
+assembly mismatches instead of analyzer regressions.
+
+The repository still does not want to publish a version-by-version host
+support matrix. However, it should validate the analyzer against the
+current .NET host versions used in development and CI.
+
+### Decision
+
+Analyzer tests use explicit `Microsoft.NETCore.App.Ref` reference
+assemblies matching the current test host target framework instead of
+implicit defaults or runtime assembly discovery.
+
+The test project runs on `net8.0`, `net9.0`, and `net10.0`, and CI test
+validation installs current .NET SDK/runtime lines so the full suite
+executes on those host TFMs.
+
+This decision does not change the public support statement for the
+packaged analyzer, which remains a `netstandard2.0` analyzer package
+without a published host-version matrix.
+
+### Consequences
+
+-   test failures are more likely to point at analyzer behavior or test
+    infrastructure changes instead of ambient host-runtime drift
+-   CI now checks the current host-runtime set explicitly, which catches
+    test-host-specific issues earlier
+-   the repository's internal validation grows stricter without
+    broadening the package's external compatibility promise
+
+### Related
+
+-   Issue: #117
+-   Pull Request:
+-   Specification reference:
+-   Related decisions:
+
+------------------------------------------------------------------------
+
 # Maintenance Rules
 
 -   Each decision should be concise.

--- a/docs/development.md
+++ b/docs/development.md
@@ -4,7 +4,8 @@ This document is for maintainers and contributors.
 
 ## Prerequisites
 
-- .NET SDK installed
+- .NET 10 SDK installed
+- .NET 8, .NET 9, and .NET 10 runtimes installed for the full test suite
 - Familiarity with Roslyn analyzer development
 - A local environment that can run unit tests for `Microsoft.CodeAnalysis.Testing`
 
@@ -14,14 +15,16 @@ Run from the repository root:
 
 ```powershell
 dotnet restore DependencyContractAnalyzer.slnx
-dotnet build DependencyContractAnalyzer.slnx -c Release --no-restore
-dotnet test DependencyContractAnalyzer.slnx -c Release --no-build
+dotnet build DependencyContractAnalyzer.slnx -c Release --no-restore -m:1
+dotnet test DependencyContractAnalyzer.slnx -c Release --no-build -m:1
 ```
+
+This test command executes the unit suite for `net8.0`, `net9.0`, and `net10.0`.
 
 To collect local coverage in Cobertura format:
 
 ```powershell
-dotnet test tests/DependencyContractAnalyzer.Tests/DependencyContractAnalyzer.Tests.csproj -c Release --collect "XPlat Code Coverage"
+dotnet test tests/DependencyContractAnalyzer.Tests/DependencyContractAnalyzer.Tests.csproj -c Release --collect "XPlat Code Coverage" -m:1
 ```
 
 The coverage file is written under `tests/DependencyContractAnalyzer.Tests/TestResults/**/coverage.cobertura.xml`.

--- a/tests/DependencyContractAnalyzer.Tests/DependencyContractAnalyzer.Tests.csproj
+++ b/tests/DependencyContractAnalyzer.Tests/DependencyContractAnalyzer.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
     <NoWarn>$(NoWarn);CS0618;NU1701</NoWarn>

--- a/tests/DependencyContractAnalyzer.Tests/DependencyContractAnalyzerVerifier.cs
+++ b/tests/DependencyContractAnalyzer.Tests/DependencyContractAnalyzerVerifier.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using DependencyContractAnalyzer.Analyzers;
 using Microsoft.CodeAnalysis;
@@ -16,6 +17,8 @@ namespace DependencyContractAnalyzer.Tests;
 
 internal static class DependencyContractAnalyzerVerifier
 {
+    private static readonly ReferenceAssemblies CurrentReferenceAssemblies = CreateCurrentReferenceAssemblies();
+
     private static readonly MetadataReference AnalyzerAssemblyReference =
         MetadataReference.CreateFromFile(typeof(ProvidesContractAttribute).Assembly.Location);
 
@@ -131,7 +134,7 @@ internal static class DependencyContractAnalyzerVerifier
     {
         public Test()
         {
-            ReferenceAssemblies = ReferenceAssemblies.Default;
+            ReferenceAssemblies = CurrentReferenceAssemblies;
         }
     }
 
@@ -276,11 +279,30 @@ internal static class DependencyContractAnalyzerVerifier
 
     private static ImmutableArray<MetadataReference> CreatePlatformMetadataReferences()
     {
-        var trustedPlatformAssemblies = ((string?)AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES"))?
-            .Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries) ??
-            Array.Empty<string>();
-        return trustedPlatformAssemblies
-            .Select(static path => (MetadataReference)MetadataReference.CreateFromFile(path))
-            .ToImmutableArray();
+        return CurrentReferenceAssemblies
+            .ResolveAsync(LanguageNames.CSharp, CancellationToken.None)
+            .GetAwaiter()
+            .GetResult();
+    }
+
+    private static ReferenceAssemblies CreateCurrentReferenceAssemblies()
+    {
+#if NET8_0
+        return CreateNetCoreReferenceAssemblies("net8.0", "8.0.0");
+#elif NET9_0
+        return CreateNetCoreReferenceAssemblies("net9.0", "9.0.0");
+#elif NET10_0
+        return CreateNetCoreReferenceAssemblies("net10.0", "10.0.0");
+#else
+#error Unsupported test target framework.
+#endif
+    }
+
+    private static ReferenceAssemblies CreateNetCoreReferenceAssemblies(string targetFramework, string packageVersion)
+    {
+        return new ReferenceAssemblies(
+            targetFramework,
+            new PackageIdentity("Microsoft.NETCore.App.Ref", packageVersion),
+            Path.Combine("ref", targetFramework));
     }
 }


### PR DESCRIPTION
## Summary
Strengthen analyzer test validation across current .NET host versions without changing the public support statement.

## Included
- replace implicit analyzer test reference-assembly selection with explicit `Microsoft.NETCore.App.Ref` usage matching the current test host TFM
- multi-target the test project for `net8.0`, `net9.0`, and `net10.0`
- update CI test setup to install current .NET SDK/runtime lines and run multi-target build/test steps with `-m:1`
- document the repository test-strategy decision and local validation expectations

## Excluded
- no change to the packaged analyzer target
- no change to the public support statement or support matrix promise

## Validation
- `dotnet build DependencyContractAnalyzer.slnx -c Release -warnaserror -m:1`
- `dotnet test DependencyContractAnalyzer.slnx -c Release --collect "XPlat Code Coverage" --results-directory artifacts/test-results -m:1`
- isolated re-check with `coverlet.collector 8.0.0` on top of this branch passed build/test for `net8.0`, `net9.0`, and `net10.0`

Closes #117