### PR TITLE
Restrict Dependabot to security updates only

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,11 +2,11 @@ version: 2
 updates:
   - package-ecosystem: "nuget"
     directory: "/"
-    target-branch: "develop"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 0
   - package-ecosystem: "github-actions"
     directory: "/"
-    target-branch: "develop"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 0

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -477,8 +477,10 @@ Record monthly and release-preparation audit results in a dedicated
 GitHub Issue, typically titled `Monthly Dependency Audit`, using
 follow-up comments instead of creating a new Issue each month.
 
-Dependabot should be configured for NuGet and GitHub Actions with a
-weekly schedule against `develop`.
+Dependabot should be configured for NuGet and GitHub Actions with
+security updates enabled. Routine Dependabot version-update Pull
+Requests should remain disabled. GitHub security update Pull Requests
+target the repository default branch.
 
 Dependabot Pull Requests follow the normal Pull Request rules:
 

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -778,6 +778,58 @@ without a published host-version matrix.
 
 ------------------------------------------------------------------------
 
+## ADR-014 Dependabot routine version updates remain disabled
+
+Status: Accepted
+Specification: Updated
+
+### Context
+
+The repository had been configured to open weekly Dependabot
+version-update Pull Requests for both NuGet packages and GitHub Actions
+against `develop`. That created routine maintenance Pull Requests even
+when no security issue existed.
+
+The repository wants to keep Dependabot security coverage while reducing
+background update churn. GitHub Dependabot security updates continue to
+work when normal version-update Pull Requests are disabled, but those
+security update Pull Requests target the repository default branch
+instead of a custom integration branch.
+
+### Decision
+
+Dependabot remains enabled for NuGet and GitHub Actions security
+updates, but routine version-update Pull Requests are disabled.
+
+The repository keeps explicit Dependabot ecosystem entries with
+`open-pull-requests-limit: 0` so normal version updates stay off while
+security updates remain available through GitHub's repository security
+update feature.
+
+The repository accepts that Dependabot security update Pull Requests
+target the default branch `main`.
+
+### Consequences
+
+-   routine dependency-refresh Pull Requests no longer appear for NuGet
+    packages or GitHub Actions
+-   vulnerability remediation Pull Requests still appear when GitHub
+    identifies a supported security update
+-   maintainers must continue scheduled dependency reviews through the
+    monthly audit process instead of relying on weekly version-update
+    Pull Requests
+-   dependency update Pull Requests now arrive on `main` when they are
+    security-driven
+
+### Related
+
+-   Issue: #119
+-   Pull Request:
+-   Specification reference:
+-   Related decisions:
+
+------------------------------------------------------------------------
+
 # Maintenance Rules
 
 -   Each decision should be concise.


### PR DESCRIPTION
## Summary
- disable routine Dependabot version-update PRs for NuGet and GitHub Actions
- keep repository guidance aligned with the security-only update policy
- record the repository-wide dependency update policy in ADR-014

## Validation
- git diff --check

Closes #119