### PR TITLE
Sync release documentation before 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 ## [Unreleased]
 
-## [1.0.0] - 2026-03-16
+## [1.0.0]
 
 ### Breaking Changes
 
@@ -80,6 +80,10 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 - Simplified Trusted Publishing configuration to use a single `NUGET_USER` secret for both nuget.org and `int.nugettest.org`
 - Switched publish routing to branch-based feed selection so `main` always targets nuget.org and `develop` always targets `int.nugettest.org`, regardless of trigger type
 - Clarified the large regression suite with section comments and targeted notes for tricky metadata/preset/inference cases
+- Strengthened analyzer test validation to execute under `net8.0`, `net9.0`, and `net10.0` with explicit current-host reference assemblies instead of implicit defaults
+- Updated local and CI coverage collection to `coverlet.collector` `8.0.0`
+- Updated GitHub Actions workflow dependencies to `actions/checkout@v6` and `actions/upload-artifact@v7`
+- Restricted Dependabot maintenance to security updates only; routine version-update Pull Requests are now disabled
 
 ### Fixed
 

--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -1,24 +1,160 @@
 # Third-Party Notices
 
 This file tracks all direct third-party dependencies used by this
-repository, including runtime, build-time, and development-time
-dependencies. Transitive dependencies are not listed by default.
+repository, including runtime, build-time, development-time, and
+workflow dependencies. Transitive dependencies are not listed by
+default.
 
 Transitive dependencies are audited at least monthly and before each
 release using `dotnet list package --include-transitive`, Dependabot,
 and GitHub security advisories. They are not listed here by default
 unless explicit notice is required.
 
-## RelaxVersioner
+## NuGet Packages
 
+### RelaxVersioner
+
+- Dependency: `RelaxVersioner` (NuGet)
+- Version: `3.21.0`
 - Project: https://github.com/kekyo/RelaxVersioner
-- Package: `RelaxVersioner` (NuGet)
 - License: Apache License 2.0 (`Apache-2.0`)
-- License text: https://www.apache.org/licenses/LICENSE-2.0
+- License text: https://licenses.nuget.org/Apache-2.0
 - Copyright:
   Copyright (c) Kouji Matsui
+- Usage note: Used as a build-time dependency to resolve package and
+  assembly versions from git tags.
+- Usage note: Referenced with `PrivateAssets="all"` and not published as
+  a package dependency.
 
-Usage note:
+### Microsoft.CodeAnalysis.Analyzers
 
-- `RelaxVersioner` is used as a build-time/development dependency to resolve package and assembly versions from git tags.
-- It is referenced with `PrivateAssets="all"` and is not redistributed as part of this package.
+- Dependency: `Microsoft.CodeAnalysis.Analyzers` (NuGet)
+- Version: `5.3.0`
+- Project: https://github.com/dotnet/roslyn
+- License: MIT License (`MIT`)
+- License text: https://licenses.nuget.org/MIT
+- Copyright:
+  Copyright (c) Microsoft Corporation. All rights reserved.
+- Usage note: Used as a development-time analyzer dependency for the
+  analyzer project build.
+- Usage note: Referenced with `PrivateAssets="all"` and not published as
+  a package dependency.
+
+### Microsoft.CodeAnalysis.CSharp
+
+- Dependency: `Microsoft.CodeAnalysis.CSharp` (NuGet)
+- Version: `5.3.0`
+- Project: https://github.com/dotnet/roslyn
+- License: MIT License (`MIT`)
+- License text: https://licenses.nuget.org/MIT
+- Copyright:
+  Copyright (c) Microsoft Corporation. All rights reserved.
+- Usage note: Used to compile the Roslyn analyzer implementation.
+- Usage note: Package dependency metadata is suppressed when packing the
+  published analyzer package.
+
+### coverlet.collector
+
+- Dependency: `coverlet.collector` (NuGet)
+- Version: `8.0.0`
+- Project: https://github.com/coverlet-coverage/coverlet
+- License: MIT License (`MIT`)
+- License text: https://licenses.nuget.org/MIT
+- Copyright:
+  Copyright (c) 2018 Toni Solarin-Sodara
+- Usage note: Used only by the test project for local and CI coverage
+  collection.
+- Usage note: Referenced with `PrivateAssets="all"` and not published as
+  a package dependency.
+
+### Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.XUnit
+
+- Dependency:
+  `Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.XUnit` (NuGet)
+- Version: `1.1.2`
+- Project: https://github.com/dotnet/roslyn-sdk
+- License: MIT License (`MIT`)
+- License text: https://licenses.nuget.org/MIT
+- Copyright:
+  Copyright (c) Microsoft Corporation. All rights reserved.
+- Usage note: Provides the Roslyn analyzer test harness used by the unit
+  test project.
+
+### Microsoft.NET.Test.Sdk
+
+- Dependency: `Microsoft.NET.Test.Sdk` (NuGet)
+- Version: `17.14.1`
+- Project: https://github.com/microsoft/vstest
+- License: MIT License (`MIT`)
+- License text: https://licenses.nuget.org/MIT
+- Copyright:
+  Copyright (c) Microsoft Corporation. All rights reserved.
+- Usage note: Provides the .NET test host and test project build
+  integration for the unit test project.
+
+### xunit
+
+- Dependency: `xunit` (NuGet)
+- Version: `2.4.2`
+- Project: https://github.com/xunit/xunit
+- License: Apache License 2.0 (`Apache-2.0`)
+- License text: https://licenses.nuget.org/Apache-2.0
+- Copyright:
+  Copyright (c) .NET Foundation
+- Usage note: Primary test framework used by the unit test project.
+
+### xunit.runner.visualstudio
+
+- Dependency: `xunit.runner.visualstudio` (NuGet)
+- Version: `2.4.5`
+- Project: https://github.com/xunit/visualstudio.xunit
+- License: MIT License (`MIT`)
+- License text: https://licenses.nuget.org/MIT
+- Copyright:
+  Copyright (c) .NET Foundation and Contributors.
+- Usage note: Visual Studio and `dotnet test` runner integration for the
+  unit test project.
+- Usage note: Referenced with `PrivateAssets="all"` and not published as
+  a package dependency.
+
+## GitHub Actions
+
+### actions/checkout
+
+- Dependency: `actions/checkout` (GitHub Action)
+- Version: `v6`
+- Project: https://github.com/actions/checkout
+- License: MIT License (`MIT`)
+- License text: https://licenses.nuget.org/MIT
+- Usage note: Used in CI and publish workflows to fetch repository
+  contents.
+
+### actions/setup-dotnet
+
+- Dependency: `actions/setup-dotnet` (GitHub Action)
+- Version: `v5`
+- Project: https://github.com/actions/setup-dotnet
+- License: MIT License (`MIT`)
+- License text: https://licenses.nuget.org/MIT
+- Usage note: Used in CI and publish workflows to install required .NET
+  SDK and runtime versions.
+
+### actions/upload-artifact
+
+- Dependency: `actions/upload-artifact` (GitHub Action)
+- Version: `v7`
+- Project: https://github.com/actions/upload-artifact
+- License: MIT License (`MIT`)
+- License text: https://licenses.nuget.org/MIT
+- Usage note: Used in CI and publish workflows to persist test results
+  and package artifacts.
+
+### NuGet/login
+
+- Dependency: `NuGet/login` (GitHub Action)
+- Version: `v1`
+- Project: https://github.com/NuGet/login
+- License: Apache License 2.0 (`Apache-2.0`)
+- License text: https://licenses.nuget.org/Apache-2.0
+- Usage note: Used in the publish workflow for NuGet Trusted Publishing
+  authentication.

--- a/docs/development.ja.md
+++ b/docs/development.ja.md
@@ -4,7 +4,9 @@
 
 ## 前提条件
 
-- .NET SDK がインストールされていること
+- .NET 10 SDK がインストールされていること
+- 完全なテスト実行のために .NET 8、.NET 9、.NET 10 runtime が
+  インストールされていること
 - Roslyn Analyzer 開発の基本知識があること
 - `Microsoft.CodeAnalysis.Testing` ベースの単体テストを実行できること
 
@@ -14,14 +16,17 @@
 
 ```powershell
 dotnet restore DependencyContractAnalyzer.slnx
-dotnet build DependencyContractAnalyzer.slnx -c Release --no-restore
-dotnet test DependencyContractAnalyzer.slnx -c Release --no-build
+dotnet build DependencyContractAnalyzer.slnx -c Release --no-restore -m:1
+dotnet test DependencyContractAnalyzer.slnx -c Release --no-build -m:1
 ```
+
+この test コマンドは `net8.0`、`net9.0`、`net10.0` の単体テスト
+スイートを実行します。
 
 ローカルで Cobertura 形式の coverage を取得する場合は次を実行します。
 
 ```powershell
-dotnet test tests/DependencyContractAnalyzer.Tests/DependencyContractAnalyzer.Tests.csproj -c Release --collect "XPlat Code Coverage"
+dotnet test tests/DependencyContractAnalyzer.Tests/DependencyContractAnalyzer.Tests.csproj -c Release --collect "XPlat Code Coverage" -m:1
 ```
 
 coverage ファイルは `tests/DependencyContractAnalyzer.Tests/TestResults/**/coverage.cobertura.xml` に出力されます。


### PR DESCRIPTION
## Summary
- keep the pending `1.0.0` changelog entry undated until the actual release tag exists
- expand `THIRD-PARTY-NOTICES.md` to cover all direct NuGet and GitHub Actions dependencies currently used by the repository
- sync `docs/development.ja.md` with the current test host/runtime guidance from the English source document

## Validation
- git diff --check