### PR TITLE
Install required SDKs in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -106,7 +106,10 @@ jobs:
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: 10.0.x
+          dotnet-version: |
+            8.0.x
+            9.0.x
+            10.0.x
           cache: true
           cache-dependency-path: |
             Directory.Build.props


### PR DESCRIPTION
## Summary
- install .NET 8, 9, and 10 in the publish workflow
- remove publish-time test execution's dependency on runner preinstalled runtimes
- address the unresolved review finding carried from PR #94

## Validation
- dotnet build DependencyContractAnalyzer.slnx -c Release --no-restore
- dotnet test DependencyContractAnalyzer.slnx -c Release