### PR TITLE
Use ubuntu-24.04 for CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ env:
 
 jobs:
   build:
-    runs-on: windows-latest
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout
@@ -42,7 +42,7 @@ jobs:
         run: dotnet build DependencyContractAnalyzer.slnx -c Release --no-restore -m:1
 
   test:
-    runs-on: windows-latest
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout
@@ -76,7 +76,7 @@ jobs:
           if-no-files-found: error
 
   analyzer:
-    runs-on: windows-latest
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout
@@ -100,7 +100,7 @@ jobs:
         run: dotnet build DependencyContractAnalyzer.slnx -c Release --no-restore -warnaserror -m:1
 
   pack:
-    runs-on: windows-latest
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary
- switch the CI workflow jobs from `windows-latest` to `ubuntu-24.04`
- keep the publish workflow unchanged for now
- track the runner experiment under #126

## Why
Recent CI runs spend more time in `Setup .NET SDK` than in `build` or `test` itself. This change isolates the CI runner OS so subsequent runs can be compared against the current Windows baseline.

## Validation
- `git diff --check`
- GitHub Issue created: #126
- Did not run GitHub Actions locally; the actual result must be verified from subsequent CI runs on GitHub