### PR TITLE
Run CI tests on windows-latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
         run: dotnet build DependencyContractAnalyzer.slnx -c Release --no-restore -m:1
 
   test:
-    runs-on: ubuntu-24.04
+    runs-on: windows-latest
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary
- move the `test` job in `.github/workflows/ci.yml` back to `windows-latest`
- keep `build`, `analyzer`, and `pack` on `ubuntu-24.04`
- implement the runner split tracked in #128

## Why
PR #127 showed that Linux materially improves the non-test CI jobs. This follow-up keeps that Linux baseline for non-test validation while preserving explicit Windows coverage for the test host, consistent with ADR-013's current-host validation direction.

## Validation
- `git diff --check`
- Did not run GitHub Actions locally; validation depends on the GitHub Actions run for this PR