### PR TITLE
Document release re-sync flow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -152,6 +152,16 @@ Releases must use a Pull Request from `develop` into `main`.
 -   manual dispatches from `main` publish to `https://www.nuget.org/`
 -   publish workflow validation enforces annotated release tags and
     branch-based feed routing
+-   after a release Pull Request is merged into `main`, `develop` MUST
+    be re-synchronized with `main` before the next development cycle
+    begins
+-   the preferred re-synchronization method is a non-destructive
+    Pull Request from `main` into `develop`; do not rewrite protected
+    branch history just to re-align release commits
+-   if branch protection requires Pull Request heads to be up to date
+    with the base branch, maintainers MUST complete this re-
+    synchronization before the next `develop` -> `main` release Pull
+    Request is merged
 
 The required CI status checks for the split workflow are `build`,
 `test`, `analyzer`, and `pack`. Repository settings must be updated to

--- a/docs/trusted-publishing.ja.md
+++ b/docs/trusted-publishing.ja.md
@@ -39,6 +39,9 @@
 - `main` の tag publish が成功した後、workflow は同じ tag から対応する GitHub Release を作成または更新します。
 - `develop` の tag publish と manual の `workflow_dispatch` 実行では GitHub Release を作成しません。
 - GitHub Release のノートは `CHANGELOG.md` の対応する `## [<version>]` セクションから生成します。
+- release Pull Request を `main` にマージした後は、次の開発サイクルを始める前に `develop` を `main` と再同期します。
+- protected branch の履歴を書き換えるのではなく、`main` から `develop` への非破壊な同期 Pull Request を推奨します。
+- GitHub branch protection が Pull Request head の up-to-date を要求する場合、この再同期を省略すると次回の `develop` -> `main` release Pull Request がブロックされることがあります。
 
 ## ブランチ運用
 
@@ -55,6 +58,7 @@
   記録済み
 - breaking-change issue を確認済み
 - release Pull Request を `main` にマージ済み
+- release merge 後に `develop` を `main` と再同期済み
 - stable version を確認済み
 - publish 先に対応する branch を確認済み
 - annotated tag を intended publish branch から作成済み

--- a/docs/trusted-publishing.md
+++ b/docs/trusted-publishing.md
@@ -39,6 +39,9 @@ Use NuGet Trusted Publishing with GitHub Actions and OpenID Connect instead of l
 - After a successful `main` tag publish, the workflow creates or updates the matching GitHub Release from that tag.
 - `develop` tag publishes and manual `workflow_dispatch` runs do not create GitHub Releases.
 - GitHub Release notes are generated from the matching `## [<version>]` section in `CHANGELOG.md`.
+- After a release Pull Request is merged into `main`, re-synchronize `develop` with `main` before starting the next development cycle.
+- Prefer a non-destructive synchronization Pull Request from `main` into `develop` instead of rewriting protected branch history.
+- If GitHub branch protection requires Pull Request heads to be up to date with the base branch, skipping this re-sync can block the next release Pull Request from `develop` into `main`.
 
 ## Branching model
 
@@ -55,6 +58,7 @@ Use NuGet Trusted Publishing with GitHub Actions and OpenID Connect instead of l
   dependency audit issue
 - breaking-change issues reviewed
 - release Pull Request merged into `main`
+- `develop` re-synchronized with `main` after the release merge
 - stable version confirmed
 - publish target branch confirmed (`main` for nuget.org or `develop` for `int.nugettest.org`)
 - annotated tag created from the intended publish branch


### PR DESCRIPTION
## Summary

- Document the required post-release main -> develop re-synchronization step.
- Clarify the interaction between that re-sync and branch protection that requires PR heads to be up to date with the base branch.
- Align the English and Japanese trusted publishing guides with the governance rule.

## Changes

- Update AGENTS.md to require re-synchronizing develop with main after release merges.
- Update docs/trusted-publishing.md with the same rule and checklist item.
- Update docs/trusted-publishing.ja.md with equivalent guidance.

## Related

- Closes #137
