### PR TITLE
Add release PR changelog advancement validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,11 @@ jobs:
         shell: pwsh
         run: ./scripts/Validate-PublishWorkflow.ps1
 
+      - name: Validate release PR changelog advancement
+        if: github.event_name == 'pull_request' && github.base_ref == 'main'
+        shell: pwsh
+        run: ./scripts/Validate-ReleasePrChangelog.ps1
+
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@v5
         with:

--- a/docs/trusted-publishing.ja.md
+++ b/docs/trusted-publishing.ja.md
@@ -50,6 +50,7 @@
 
 ## Release チェックリスト
 
+- `main` 向け release Pull Request では、`main` から到達可能な最新 release tag より新しい `## [<version>]` セクションを `CHANGELOG.md` に含めている
 - `CHANGELOG.md` を更新済み
 - translation follow-up を確認済み
 - docs-sync を確認済み

--- a/docs/trusted-publishing.md
+++ b/docs/trusted-publishing.md
@@ -50,6 +50,7 @@ Use NuGet Trusted Publishing with GitHub Actions and OpenID Connect instead of l
 
 ## Release checklist
 
+- Release PRs into `main` must advance `CHANGELOG.md` with at least one `## [<version>]` section newer than the latest release tag already reachable from `main`
 - `CHANGELOG.md` updated
 - translation follow-up checked
 - docs-sync checked

--- a/scripts/Validate-CiWorkflow.ps1
+++ b/scripts/Validate-CiWorkflow.ps1
@@ -9,6 +9,9 @@ $requiredFragments = [ordered]@{
     'test validation command' = 'run: dotnet test DependencyContractAnalyzer.slnx -c Release --no-restore --collect "XPlat Code Coverage" --results-directory artifacts/test-results'
     'analyzer validation command' = 'run: dotnet build DependencyContractAnalyzer.slnx -c Release --no-restore -warnaserror'
     'pack validation command' = 'run: dotnet pack src/DependencyContractAnalyzer/DependencyContractAnalyzer.csproj -c Release --no-restore -o artifacts'
+    'release PR changelog validation step name' = '- name: Validate release PR changelog advancement'
+    'release PR changelog validation condition' = "if: github.event_name == 'pull_request' && github.base_ref == 'main'"
+    'release PR changelog validation command' = 'run: ./scripts/Validate-ReleasePrChangelog.ps1'
 }
 
 foreach ($requiredFragment in $requiredFragments.GetEnumerator()) {

--- a/scripts/Validate-ReleasePrChangelog.ps1
+++ b/scripts/Validate-ReleasePrChangelog.ps1
@@ -1,0 +1,85 @@
+param(
+    [string]$RepositoryRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path,
+    [string]$ReleaseBranchName = 'main',
+    [string]$RemoteName = 'origin',
+    [switch]$SkipFetch
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Invoke-GitCommand {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string[]]$Arguments
+    )
+
+    $output = & git @Arguments 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        $commandText = ($Arguments -join ' ')
+        $message = if ($output) { ($output | Out-String).Trim() } else { 'No output.' }
+        throw "Git command failed: git $commandText`n$message"
+    }
+
+    return @($output)
+}
+
+function Get-ChangelogVersions {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$ChangelogPath
+    )
+
+    $versionPattern = '^\s*## \[(?<version>\d+\.\d+\.\d+)\]\s*$'
+    $versions = [System.Collections.Generic.List[Version]]::new()
+
+    foreach ($line in Get-Content $ChangelogPath) {
+        $match = [regex]::Match($line, $versionPattern)
+        if (-not $match.Success) {
+            continue
+        }
+
+        $versions.Add([Version]::Parse($match.Groups['version'].Value))
+    }
+
+    return $versions
+}
+
+$resolvedRepositoryRoot = (Resolve-Path $RepositoryRoot).Path
+Push-Location $resolvedRepositoryRoot
+
+try {
+    if (-not $SkipFetch) {
+        $remoteRefSpec = "refs/heads/$ReleaseBranchName`:refs/remotes/$RemoteName/$ReleaseBranchName"
+        Invoke-GitCommand -Arguments @('fetch', $RemoteName, $remoteRefSpec, '--tags') | Out-Null
+    }
+
+    $releaseBranchRef = if ($SkipFetch) { $ReleaseBranchName } else { "$RemoteName/$ReleaseBranchName" }
+    $mainReleaseTags = @(Invoke-GitCommand -Arguments @('tag', '--merged', $releaseBranchRef, '--list', 'v[0-9]*.[0-9]*.[0-9]*', '--sort=-version:refname') |
+        Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+
+    $latestReleaseVersion = $null
+    if ($mainReleaseTags.Count -gt 0) {
+        $latestReleaseVersion = [Version]::Parse($mainReleaseTags[0].Substring(1))
+    }
+
+    $changelogPath = Join-Path $resolvedRepositoryRoot 'CHANGELOG.md'
+    $changelogVersions = @(Get-ChangelogVersions -ChangelogPath $changelogPath)
+    if ($changelogVersions.Count -eq 0) {
+        throw 'CHANGELOG.md does not contain any version sections.'
+    }
+
+    $hasAdvancedVersion = if ($null -eq $latestReleaseVersion) {
+        $true
+    }
+    else {
+        $changelogVersions | Where-Object { $_ -gt $latestReleaseVersion } | Select-Object -First 1
+    }
+
+    if (-not $hasAdvancedVersion) {
+        throw "CHANGELOG.md must contain at least one version section newer than the latest $ReleaseBranchName release tag v$latestReleaseVersion."
+    }
+}
+finally {
+    Pop-Location
+}

--- a/tests/DependencyContractAnalyzer.Tests/ReleasePrChangelogValidationTests.cs
+++ b/tests/DependencyContractAnalyzer.Tests/ReleasePrChangelogValidationTests.cs
@@ -1,0 +1,185 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+using Xunit;
+
+namespace DependencyContractAnalyzer.Tests;
+
+public sealed class ReleasePrChangelogValidationTests
+{
+    [Fact]
+    public void ValidateReleasePrChangelogSucceedsWhenChangelogAdvancesPastLatestMainTag()
+    {
+        using TemporaryGitRepository repository = TemporaryGitRepository.Create();
+        repository.WriteChangelog(
+            """
+            # Changelog
+
+            ## [Unreleased]
+
+            ## [1.1.0]
+
+            ### Added
+
+            - Pending release notes
+
+            ## [1.0.0]
+
+            ### Added
+
+            - Initial release
+            """);
+
+        repository.CommitAll("Add changelog");
+        repository.CreateAnnotatedTag("v1.0.0", "1.0.0");
+
+        RunValidationScript(repository.Path);
+    }
+
+    [Fact]
+    public void ValidateReleasePrChangelogFailsWhenChangelogDoesNotAdvancePastLatestMainTag()
+    {
+        using TemporaryGitRepository repository = TemporaryGitRepository.Create();
+        repository.WriteChangelog(
+            """
+            # Changelog
+
+            ## [Unreleased]
+
+            ## [1.0.0]
+
+            ### Added
+
+            - Initial release
+            """);
+
+        repository.CommitAll("Add changelog");
+        repository.CreateAnnotatedTag("v1.0.0", "1.0.0");
+
+        InvalidOperationException exception = Assert.Throws<InvalidOperationException>(() => RunValidationScript(repository.Path));
+        Assert.Contains("CHANGELOG.md must contain at least one version section newer than the latest main release tag v1.0.0.", exception.Message, StringComparison.Ordinal);
+    }
+
+    private static void RunValidationScript(string repositoryPath)
+    {
+        string scriptPath = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "..", "scripts", "Validate-ReleasePrChangelog.ps1"));
+        ProcessStartInfo startInfo = new()
+        {
+            FileName = GetPowerShellExecutableName(),
+            WorkingDirectory = repositoryPath,
+            RedirectStandardError = true,
+            RedirectStandardOutput = true,
+        };
+
+        startInfo.ArgumentList.Add("-NoProfile");
+        startInfo.ArgumentList.Add("-File");
+        startInfo.ArgumentList.Add(scriptPath);
+        startInfo.ArgumentList.Add("-RepositoryRoot");
+        startInfo.ArgumentList.Add(repositoryPath);
+        startInfo.ArgumentList.Add("-ReleaseBranchName");
+        startInfo.ArgumentList.Add("main");
+        startInfo.ArgumentList.Add("-SkipFetch");
+
+        using Process process = Process.Start(startInfo) ?? throw new InvalidOperationException("Failed to start PowerShell process.");
+        string standardOutput = process.StandardOutput.ReadToEnd();
+        string standardError = process.StandardError.ReadToEnd();
+        process.WaitForExit();
+
+        if (process.ExitCode == 0) {
+            return;
+        }
+
+        string combinedOutput = string.Join(
+            Environment.NewLine,
+            new[] { standardOutput, standardError }.Where(static text => !string.IsNullOrWhiteSpace(text)));
+
+        throw new InvalidOperationException(combinedOutput);
+    }
+
+    private static string GetPowerShellExecutableName()
+    {
+        return RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "pwsh.exe" : "pwsh";
+    }
+
+    private sealed class TemporaryGitRepository : IDisposable
+    {
+        private TemporaryGitRepository(string path)
+        {
+            Path = path;
+        }
+
+        public string Path { get; }
+
+        public static TemporaryGitRepository Create()
+        {
+            string path = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "dca-release-pr-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(path);
+
+            TemporaryGitRepository repository = new(path);
+            repository.RunGit("init", "--initial-branch=main");
+            repository.RunGit("config", "user.name", "Dependency Contract Analyzer Tests");
+            repository.RunGit("config", "user.email", "tests@example.invalid");
+
+            return repository;
+        }
+
+        public void WriteChangelog(string content)
+        {
+            File.WriteAllText(System.IO.Path.Combine(Path, "CHANGELOG.md"), content.ReplaceLineEndings("\n"));
+        }
+
+        public void CommitAll(string message)
+        {
+            RunGit("add", "CHANGELOG.md");
+            RunGit("commit", "-m", message);
+        }
+
+        public void CreateAnnotatedTag(string tagName, string message)
+        {
+            RunGit("tag", "-a", tagName, "-m", message);
+        }
+
+        public void Dispose()
+        {
+            try {
+                Directory.Delete(Path, recursive: true);
+            }
+            catch (IOException) {
+            }
+            catch (UnauthorizedAccessException) {
+            }
+        }
+
+        private void RunGit(params string[] arguments)
+        {
+            ProcessStartInfo startInfo = new()
+            {
+                FileName = "git",
+                WorkingDirectory = Path,
+                RedirectStandardError = true,
+                RedirectStandardOutput = true,
+            };
+
+            foreach (string argument in arguments) {
+                startInfo.ArgumentList.Add(argument);
+            }
+
+            using Process process = Process.Start(startInfo) ?? throw new InvalidOperationException("Failed to start git.");
+            string standardOutput = process.StandardOutput.ReadToEnd();
+            string standardError = process.StandardError.ReadToEnd();
+            process.WaitForExit();
+
+            if (process.ExitCode == 0) {
+                return;
+            }
+
+            string combinedOutput = string.Join(
+                Environment.NewLine,
+                new[] { standardOutput, standardError }.Where(static text => !string.IsNullOrWhiteSpace(text)));
+
+            throw new InvalidOperationException($"git {string.Join(' ', arguments)} failed.{Environment.NewLine}{combinedOutput}");
+        }
+    }
+}

--- a/tests/DependencyContractAnalyzer.Tests/ReleasePrChangelogValidationTests.cs
+++ b/tests/DependencyContractAnalyzer.Tests/ReleasePrChangelogValidationTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Text.RegularExpressions;
 using System.Runtime.InteropServices;
 using Xunit;
 
@@ -59,7 +60,8 @@ public sealed class ReleasePrChangelogValidationTests
         repository.CreateAnnotatedTag("v1.0.0", "1.0.0");
 
         InvalidOperationException exception = Assert.Throws<InvalidOperationException>(() => RunValidationScript(repository.Path));
-        Assert.Contains("CHANGELOG.md must contain at least one version section newer than the latest main release tag v1.0.0.", exception.Message, StringComparison.Ordinal);
+        string sanitizedMessage = StripAnsiEscapeSequences(exception.Message);
+        Assert.Contains("CHANGELOG.md must contain at least one version section newer than the latest main release tag v1.0.0.", sanitizedMessage, StringComparison.Ordinal);
     }
 
     private static void RunValidationScript(string repositoryPath)
@@ -101,6 +103,11 @@ public sealed class ReleasePrChangelogValidationTests
     private static string GetPowerShellExecutableName()
     {
         return RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "pwsh.exe" : "pwsh";
+    }
+
+    private static string StripAnsiEscapeSequences(string text)
+    {
+        return Regex.Replace(text, "\u001B\\[[0-9;]*[A-Za-z]", string.Empty);
     }
 
     private sealed class TemporaryGitRepository : IDisposable

--- a/tests/DependencyContractAnalyzer.Tests/ReleasePrChangelogValidationTests.cs
+++ b/tests/DependencyContractAnalyzer.Tests/ReleasePrChangelogValidationTests.cs
@@ -61,7 +61,8 @@ public sealed class ReleasePrChangelogValidationTests
 
         InvalidOperationException exception = Assert.Throws<InvalidOperationException>(() => RunValidationScript(repository.Path));
         string sanitizedMessage = StripAnsiEscapeSequences(exception.Message);
-        Assert.Contains("CHANGELOG.md must contain at least one version section newer than the latest main release tag v1.0.0.", sanitizedMessage, StringComparison.Ordinal);
+        Assert.Contains("CHANGELOG.md must contain at least one version section newer than", sanitizedMessage, StringComparison.Ordinal);
+        Assert.Contains("latest main release tag v1.0.0.", sanitizedMessage, StringComparison.Ordinal);
     }
 
     private static void RunValidationScript(string repositoryPath)


### PR DESCRIPTION
## Summary
- add a CI-only changelog advancement check for pull requests targeting main
- validate the new workflow contract with a dedicated PowerShell script and invariant coverage
- add regression tests for passing and failing changelog advancement cases and document the release checklist change

## Testing
- dotnet test tests/DependencyContractAnalyzer.Tests/DependencyContractAnalyzer.Tests.csproj -c Release --no-restore
- dotnet build DependencyContractAnalyzer.slnx -c Release --no-restore -warnaserror
- pwsh -NoProfile -File ./scripts/Validate-CiWorkflow.ps1
- pwsh -NoProfile -File ./scripts/Validate-PublishWorkflow.ps1

Refs #140