### PR TITLE
Release 1.2.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,7 +141,7 @@ jobs:
 
       - name: Pack
         shell: pwsh
-        run: ./scripts/Invoke-PackWithSbom.ps1 -ProjectPath src/DependencyContractAnalyzer/DependencyContractAnalyzer.csproj -Configuration Release -OutputDirectory artifacts -AdditionalDotNetPackArguments '--no-restore' -SyftVersion ${{ env.SYFT_VERSION }} -DownloadSyftIfMissing
+        run: ./scripts/Invoke-PackWithSbom.ps1 -ProjectPath src/DependencyContractAnalyzer/DependencyContractAnalyzer.csproj -Configuration Release -OutputDirectory artifacts -NoRestore -SyftVersion ${{ env.SYFT_VERSION }} -DownloadSyftIfMissing
 
       - name: Self-test packed package smoke script
         shell: pwsh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ permissions:
 
 env:
   DOTNET_VERSION: 10.0.x
+  SYFT_VERSION: v1.42.3
 
 jobs:
   build:
@@ -139,7 +140,8 @@ jobs:
         run: dotnet restore DependencyContractAnalyzer.slnx
 
       - name: Pack
-        run: dotnet pack src/DependencyContractAnalyzer/DependencyContractAnalyzer.csproj -c Release --no-restore -o artifacts
+        shell: pwsh
+        run: ./scripts/Invoke-PackWithSbom.ps1 -ProjectPath src/DependencyContractAnalyzer/DependencyContractAnalyzer.csproj -Configuration Release -OutputDirectory artifacts -AdditionalDotNetPackArguments '--no-restore' -SyftVersion ${{ env.SYFT_VERSION }} -DownloadSyftIfMissing
 
       - name: Self-test packed package smoke script
         shell: pwsh

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -174,7 +174,7 @@ jobs:
 
       - name: Pack
         shell: pwsh
-        run: ./scripts/Invoke-PackWithSbom.ps1 -ProjectPath src/DependencyContractAnalyzer/DependencyContractAnalyzer.csproj -Configuration Release -OutputDirectory artifacts -AdditionalDotNetPackArguments '--no-build', '-p:RelaxVersionerCheckWorkingDirectoryStatus=false' -SyftVersion ${{ env.SYFT_VERSION }} -DownloadSyftIfMissing
+        run: ./scripts/Invoke-PackWithSbom.ps1 -ProjectPath src/DependencyContractAnalyzer/DependencyContractAnalyzer.csproj -Configuration Release -OutputDirectory artifacts -NoBuild -PackProperties 'RelaxVersionerCheckWorkingDirectoryStatus=false' -SyftVersion ${{ env.SYFT_VERSION }} -DownloadSyftIfMissing
 
       - name: Verify package version resolved from release tag
         if: github.event_name == 'push'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,6 +15,7 @@ jobs:
     runs-on: windows-latest
     env:
       NUGET_USER: ${{ secrets.NUGET_USER }}
+      SYFT_VERSION: v1.42.3
 
     steps:
       - name: Checkout
@@ -172,7 +173,8 @@ jobs:
         run: dotnet test DependencyContractAnalyzer.slnx -c Release --no-build
 
       - name: Pack
-        run: dotnet pack src/DependencyContractAnalyzer/DependencyContractAnalyzer.csproj -c Release --no-build -p:RelaxVersionerCheckWorkingDirectoryStatus=false -o artifacts
+        shell: pwsh
+        run: ./scripts/Invoke-PackWithSbom.ps1 -ProjectPath src/DependencyContractAnalyzer/DependencyContractAnalyzer.csproj -Configuration Release -OutputDirectory artifacts -AdditionalDotNetPackArguments '--no-build', '-p:RelaxVersionerCheckWorkingDirectoryStatus=false' -SyftVersion ${{ env.SYFT_VERSION }} -DownloadSyftIfMissing
 
       - name: Verify package version resolved from release tag
         if: github.event_name == 'push'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 ## [Unreleased]
 
+### Added
+
+- Embedded a `Syft`-generated CycloneDX SBOM as `sbom.cdx.json` in the
+  distributed `.nupkg` artifact
+
+### Changed
+
+- Routed CI and publish package generation through a shared SBOM-aware
+  pack script and extended packed-package smoke validation to assert the
+  embedded SBOM is present
+
 ## [1.1.0]
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on Keep a Changelog, and this project follows Semantic Versi
 
 ## [Unreleased]
 
+## [1.2.0]
+
 ### Added
 
 - Embedded a `Syft`-generated CycloneDX SBOM as `sbom.cdx.json` in the

--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -10,6 +10,13 @@ release using `dotnet list package --include-transitive`, Dependabot,
 and GitHub security advisories. They are not listed here by default
 unless explicit notice is required.
 
+## Trademark Notices
+
+Microsoft, NuGet, and Roslyn are trademarks of the Microsoft group of
+companies.
+
+GitHub is a trademark of GitHub, Inc.
+
 ## NuGet Packages
 
 ### RelaxVersioner
@@ -66,6 +73,19 @@ unless explicit notice is required.
   collection.
 - Usage note: Referenced with `PrivateAssets="all"` and not published as
   a package dependency.
+
+### Syft
+
+- Dependency: `Syft` (CLI tool)
+- Version: `1.42.3`
+- Project: https://github.com/anchore/syft
+- License: Apache License 2.0 (`Apache-2.0`)
+- License text: https://github.com/anchore/syft/blob/v1.42.3/LICENSE
+- Copyright:
+  Copyright Anchore, Inc.
+- Usage note: Used in CI and publish workflows to generate a CycloneDX
+  SBOM for the distributed NuGet package and embed it into the packaged
+  artifact.
 
 ### Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.XUnit
 

--- a/docs/development.ja.md
+++ b/docs/development.ja.md
@@ -36,7 +36,7 @@ coverage ファイルは `tests/DependencyContractAnalyzer.Tests/TestResults/**/
 ローカルでの pack:
 
 ```powershell
-pwsh -NoProfile -File ./scripts/Invoke-PackWithSbom.ps1 -ProjectPath src/DependencyContractAnalyzer/DependencyContractAnalyzer.csproj -Configuration Release -OutputDirectory artifacts -AdditionalDotNetPackArguments '--no-build' -SyftVersion v1.42.3 -DownloadSyftIfMissing
+pwsh -NoProfile -File ./scripts/Invoke-PackWithSbom.ps1 -ProjectPath src/DependencyContractAnalyzer/DependencyContractAnalyzer.csproj -Configuration Release -OutputDirectory artifacts -NoBuild -SyftVersion v1.42.3 -DownloadSyftIfMissing
 ```
 
 この package build script は、pack 後の package 内容に対して `Syft`

--- a/docs/development.ja.md
+++ b/docs/development.ja.md
@@ -9,6 +9,8 @@
   インストールされていること
 - Roslyn Analyzer 開発の基本知識があること
 - `Microsoft.CodeAnalysis.Testing` ベースの単体テストを実行できること
+- `Syft` が `PATH` 上にあること、または SBOM 付き pack script が
+  pin された release を自動取得できる network access があること
 
 ## 典型的なローカル検証
 
@@ -34,15 +36,19 @@ coverage ファイルは `tests/DependencyContractAnalyzer.Tests/TestResults/**/
 ローカルでの pack:
 
 ```powershell
-dotnet pack src/DependencyContractAnalyzer/DependencyContractAnalyzer.csproj -c Release --no-build -o artifacts
+pwsh -NoProfile -File ./scripts/Invoke-PackWithSbom.ps1 -ProjectPath src/DependencyContractAnalyzer/DependencyContractAnalyzer.csproj -Configuration Release -OutputDirectory artifacts -AdditionalDotNetPackArguments '--no-build' -SyftVersion v1.42.3 -DownloadSyftIfMissing
 ```
+
+この package build script は、pack 後の package 内容に対して `Syft`
+で CycloneDX SBOM を生成し、`.nupkg` ルートへ `sbom.cdx.json` として
+同梱します。
 
 packaged package の smoke validation は、単一の `.nupkg` だけを含む
 clean な package directory を前提とし、現在は `net8.0`、`net9.0`、
 `net10.0` で package 消費を検証します。
 
 ```powershell
-dotnet pack src/DependencyContractAnalyzer/DependencyContractAnalyzer.csproj -c Release -o artifacts/package-smoke-current
+pwsh -NoProfile -File ./scripts/Invoke-PackWithSbom.ps1 -ProjectPath src/DependencyContractAnalyzer/DependencyContractAnalyzer.csproj -Configuration Release -OutputDirectory artifacts/package-smoke-current -SyftVersion v1.42.3 -DownloadSyftIfMissing
 pwsh -NoProfile -File ./scripts/Test-PackedPackageConsumption.ps1 -PackageDirectory artifacts/package-smoke-current
 ```
 
@@ -92,6 +98,7 @@ packaged analyzer の互換が保たれる限り、現時点の実装は `.NET 5
 ## リリース
 
 - CI 検証は `.github/workflows/ci.yml` で定義しています。
-- CI では package artifact に加えて `dotnet test` の test result / coverage artifact も保存します。
+- CI では SBOM を同梱した package artifact に加えて `dotnet test`
+  の test result / coverage artifact も保存します。
 - NuGet.org への公開方針は `docs/trusted-publishing.ja.md` を参照してください。
 - リリース publish は `.github/workflows/publish.yml` で定義しています。

--- a/docs/development.md
+++ b/docs/development.md
@@ -8,6 +8,8 @@ This document is for maintainers and contributors.
 - .NET 8, .NET 9, and .NET 10 runtimes installed for the full test suite
 - Familiarity with Roslyn analyzer development
 - A local environment that can run unit tests for `Microsoft.CodeAnalysis.Testing`
+- `Syft` available on `PATH`, or network access available for the SBOM
+  pack script to download the pinned release automatically
 
 ## Typical local validation
 
@@ -32,15 +34,19 @@ The coverage file is written under `tests/DependencyContractAnalyzer.Tests/TestR
 Local package output:
 
 ```powershell
-dotnet pack src/DependencyContractAnalyzer/DependencyContractAnalyzer.csproj -c Release --no-build -o artifacts
+pwsh -NoProfile -File ./scripts/Invoke-PackWithSbom.ps1 -ProjectPath src/DependencyContractAnalyzer/DependencyContractAnalyzer.csproj -Configuration Release -OutputDirectory artifacts -AdditionalDotNetPackArguments '--no-build' -SyftVersion v1.42.3 -DownloadSyftIfMissing
 ```
+
+The package build script generates a CycloneDX SBOM with `Syft` from the
+packed package contents and embeds it as `sbom.cdx.json` in the `.nupkg`
+root.
 
 Packed-package smoke validation expects a clean package directory with a
 single `.nupkg` and currently verifies package consumption on `net8.0`,
 `net9.0`, and `net10.0`:
 
 ```powershell
-dotnet pack src/DependencyContractAnalyzer/DependencyContractAnalyzer.csproj -c Release -o artifacts/package-smoke-current
+pwsh -NoProfile -File ./scripts/Invoke-PackWithSbom.ps1 -ProjectPath src/DependencyContractAnalyzer/DependencyContractAnalyzer.csproj -Configuration Release -OutputDirectory artifacts/package-smoke-current -SyftVersion v1.42.3 -DownloadSyftIfMissing
 pwsh -NoProfile -File ./scripts/Test-PackedPackageConsumption.ps1 -PackageDirectory artifacts/package-smoke-current
 ```
 
@@ -92,6 +98,7 @@ The repository currently follows this structure:
 ## Release
 
 - CI validation is defined in `.github/workflows/ci.yml`.
-- CI uploads both package artifacts and `dotnet test` coverage/test-result artifacts.
+- CI uploads both SBOM-embedded package artifacts and `dotnet test`
+  coverage/test-result artifacts.
 - NuGet.org publishing guidance is documented in `docs/trusted-publishing.md`.
 - Release publishing is defined in `.github/workflows/publish.yml`.

--- a/docs/development.md
+++ b/docs/development.md
@@ -34,7 +34,7 @@ The coverage file is written under `tests/DependencyContractAnalyzer.Tests/TestR
 Local package output:
 
 ```powershell
-pwsh -NoProfile -File ./scripts/Invoke-PackWithSbom.ps1 -ProjectPath src/DependencyContractAnalyzer/DependencyContractAnalyzer.csproj -Configuration Release -OutputDirectory artifacts -AdditionalDotNetPackArguments '--no-build' -SyftVersion v1.42.3 -DownloadSyftIfMissing
+pwsh -NoProfile -File ./scripts/Invoke-PackWithSbom.ps1 -ProjectPath src/DependencyContractAnalyzer/DependencyContractAnalyzer.csproj -Configuration Release -OutputDirectory artifacts -NoBuild -SyftVersion v1.42.3 -DownloadSyftIfMissing
 ```
 
 The package build script generates a CycloneDX SBOM with `Syft` from the

--- a/docs/trusted-publishing.ja.md
+++ b/docs/trusted-publishing.ja.md
@@ -35,6 +35,9 @@
 - tag push の publish 先は trigger 種別ではなく branch により決まり、`main` の tag は `https://www.nuget.org/api/v2/package`、`develop` の tag は `https://int.nugettest.org/api/v2/package` に publish します。
 - tag 対象 commit が `main` と `develop` の両方から到達可能、またはどちらからも到達不可能な場合は publish を失敗させます。
 - publish 時の pack step では、生成された build output によって package version が勝手に繰り上がらないように、RelaxVersioner の working-directory dirty check を無効化します。
+- pack 経路では `Syft` `v1.42.3` を使って pack 後の package 内容から
+  CycloneDX SBOM を生成し、`.nupkg` に `sbom.cdx.json` として同梱
+  します。
 - tag push では upload 前に、生成された `.nupkg` のファイル名が release tag の version と一致することを検証します。
 - `main` の tag publish が成功した後、workflow は同じ tag から対応する GitHub Release を作成または更新します。
 - `develop` の tag publish と manual の `workflow_dispatch` 実行では GitHub Release を作成しません。

--- a/docs/trusted-publishing.ja.md
+++ b/docs/trusted-publishing.ja.md
@@ -17,7 +17,7 @@
 7. nuget.org と `int.nugettest.org` の両方で publish 可能なアカウント名を repository secret `NUGET_USER` に設定します。
 8. publish ワークフローで `permissions.id-token: write` と `permissions.contents: write` を維持します。
 9. annotated tag として `v<major>.<minor>.<patch>` 形式の release tag を
-   作成して push します。例: `v0.1.0`
+   作成して push します。例: `v1.2.0`
 10. パッケージ/アセンブリ バージョンは `RelaxVersioner` により git タグから解決します。
 
 ## ワークフロー要件

--- a/docs/trusted-publishing.md
+++ b/docs/trusted-publishing.md
@@ -35,6 +35,9 @@ Use NuGet Trusted Publishing with GitHub Actions and OpenID Connect instead of l
 - Tag pushes publish by branch instead of by trigger type: `main` tags publish to `https://www.nuget.org/api/v2/package`, and `develop` tags publish to `https://int.nugettest.org/api/v2/package`.
 - Tag pushes fail when the tagged commit is reachable from both `main` and `develop`, or from neither branch.
 - The publish-time pack step disables RelaxVersioner's working-directory dirty check so generated build outputs do not silently bump the package version.
+- The pack workflow path uses `Syft` `v1.42.3` to generate a CycloneDX
+  SBOM from the packed package contents and embeds it as
+  `sbom.cdx.json` in the `.nupkg`.
 - Tag pushes verify that the generated `.nupkg` filename matches the release tag version before upload.
 - After a successful `main` tag publish, the workflow creates or updates the matching GitHub Release from that tag.
 - `develop` tag publishes and manual `workflow_dispatch` runs do not create GitHub Releases.

--- a/docs/trusted-publishing.md
+++ b/docs/trusted-publishing.md
@@ -17,7 +17,7 @@ Use NuGet Trusted Publishing with GitHub Actions and OpenID Connect instead of l
 7. Configure the repository secret `NUGET_USER` with the account name that is allowed to publish the package on both nuget.org and `int.nugettest.org`.
 8. Ensure the publish workflow keeps `permissions.id-token: write` and `permissions.contents: write`.
 9. Create and push an annotated release tag using the format
-   `v<major>.<minor>.<patch>`, such as `v0.1.0`.
+   `v<major>.<minor>.<patch>`, such as `v1.2.0`.
 10. Package and assembly versions are resolved from git tags by `RelaxVersioner`.
 
 ## Workflow expectations

--- a/scripts/Invoke-PackWithSbom.ps1
+++ b/scripts/Invoke-PackWithSbom.ps1
@@ -14,6 +14,7 @@ Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
 Add-Type -AssemblyName System.IO.Compression.FileSystem
+Add-Type -AssemblyName System.Runtime
 
 $script:EmbeddedSbomFileName = 'sbom.cdx.json'
 
@@ -43,19 +44,94 @@ function Get-SyftDownloadAssetName {
         [string]$VersionWithoutPrefix
     )
 
+    $architectureSuffix = switch ([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture) {
+        ([System.Runtime.InteropServices.Architecture]::X64) { 'amd64' }
+        ([System.Runtime.InteropServices.Architecture]::Arm64) { 'arm64' }
+        default { throw "Syft auto-download is not supported for process architecture '$([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture)'." }
+    }
+
     if ($IsWindows) {
-        return "syft_${VersionWithoutPrefix}_windows_amd64.zip"
+        return "syft_${VersionWithoutPrefix}_windows_${architectureSuffix}.zip"
     }
 
     if ($IsLinux) {
-        return "syft_${VersionWithoutPrefix}_linux_amd64.tar.gz"
+        return "syft_${VersionWithoutPrefix}_linux_${architectureSuffix}.tar.gz"
     }
 
     if ($IsMacOS) {
-        return "syft_${VersionWithoutPrefix}_darwin_amd64.tar.gz"
+        return "syft_${VersionWithoutPrefix}_darwin_${architectureSuffix}.tar.gz"
     }
 
     throw 'Syft auto-download is not supported on this operating system.'
+}
+
+function Get-SyftVersion {
+    param(
+        [string]$ExecutablePath
+    )
+
+    $versionOutput = & $ExecutablePath 'version' '--output' 'json' 2>$null
+    if ($LASTEXITCODE -eq 0) {
+        try {
+            $parsedVersion = $versionOutput | ConvertFrom-Json
+            if (-not [string]::IsNullOrWhiteSpace($parsedVersion.version)) {
+                return [string]$parsedVersion.version
+            }
+        }
+        catch {
+        }
+    }
+
+    $versionOutput = & $ExecutablePath 'version' 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        throw "Failed to determine the version of Syft executable '$ExecutablePath'."
+    }
+
+    foreach ($outputLine in $versionOutput) {
+        if ($outputLine -match 'Version:\s*(?<Version>\S+)') {
+            return $Matches['Version']
+        }
+    }
+
+    throw "Failed to parse the version of Syft executable '$ExecutablePath'."
+}
+
+function Get-FileSha256 {
+    param(
+        [string]$Path
+    )
+
+    return (Get-FileHash -LiteralPath $Path -Algorithm SHA256).Hash.ToLowerInvariant()
+}
+
+function Assert-DownloadedFileMatchesChecksum {
+    param(
+        [string]$ArchivePath,
+        [string]$ChecksumsPath,
+        [string]$AssetName
+    )
+
+    $expectedChecksum = $null
+    foreach ($checksumLine in Get-Content -LiteralPath $ChecksumsPath) {
+        $trimmedLine = $checksumLine.Trim()
+        if ([string]::IsNullOrWhiteSpace($trimmedLine)) {
+            continue
+        }
+
+        if ($trimmedLine -match '^(?<Checksum>[0-9A-Fa-f]{64})\s+[* ](?<Name>.+)$' -and $Matches['Name'] -eq $AssetName) {
+            $expectedChecksum = $Matches['Checksum'].ToLowerInvariant()
+            break
+        }
+    }
+
+    if ($null -eq $expectedChecksum) {
+        throw "Failed to locate checksum entry for '$AssetName' in '$ChecksumsPath'."
+    }
+
+    $actualChecksum = Get-FileSha256 -Path $ArchivePath
+    if ($actualChecksum -ne $expectedChecksum) {
+        throw "Checksum verification failed for '$AssetName'. Expected '$expectedChecksum', got '$actualChecksum'."
+    }
 }
 
 function Install-SyftIfNeeded {
@@ -67,7 +143,16 @@ function Install-SyftIfNeeded {
 
     $resolvedCommand = Get-Command $RequestedSyftPath -ErrorAction SilentlyContinue
     if ($null -ne $resolvedCommand) {
-        return $resolvedCommand.Source
+        if ([string]::IsNullOrWhiteSpace($RequestedSyftVersion)) {
+            return $resolvedCommand.Source
+        }
+
+        $resolvedVersion = Get-SyftVersion -ExecutablePath $resolvedCommand.Source
+        if ($resolvedVersion -eq $RequestedSyftVersion.TrimStart('v')) {
+            return $resolvedCommand.Source
+        }
+
+        Write-Host "Found Syft '$resolvedVersion' on PATH, but '$RequestedSyftVersion' is required. Downloading the pinned release."
     }
 
     if (-not $AllowDownload.IsPresent) {
@@ -80,32 +165,51 @@ function Install-SyftIfNeeded {
 
     $versionWithoutPrefix = $RequestedSyftVersion.TrimStart('v')
     $assetName = Get-SyftDownloadAssetName -VersionWithoutPrefix $versionWithoutPrefix
+    $checksumsFileName = "syft_${versionWithoutPrefix}_checksums.txt"
     $downloadUrl = "https://github.com/anchore/syft/releases/download/$RequestedSyftVersion/$assetName"
-    $installRoot = Join-Path ([System.IO.Path]::GetTempPath()) "dca-syft-$versionWithoutPrefix"
-    $archivePath = Join-Path ([System.IO.Path]::GetTempPath()) $assetName
+    $checksumsUrl = "https://github.com/anchore/syft/releases/download/$RequestedSyftVersion/$checksumsFileName"
+    $tempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("dca-syft-$versionWithoutPrefix-" + [System.Guid]::NewGuid().ToString('N'))
+    $installRoot = Join-Path $tempRoot 'install'
+    $archivePath = Join-Path $tempRoot $assetName
+    $checksumsPath = Join-Path $tempRoot $checksumsFileName
 
-    if (Test-Path -LiteralPath $installRoot) {
-        Remove-Item -LiteralPath $installRoot -Recurse -Force
+    New-Item -ItemType Directory -Path $installRoot -Force | Out-Null
+
+    try {
+        Write-Host "Downloading Syft $RequestedSyftVersion from $downloadUrl"
+        Invoke-WebRequest -Uri $downloadUrl -OutFile $archivePath
+        Invoke-WebRequest -Uri $checksumsUrl -OutFile $checksumsPath
+        Assert-DownloadedFileMatchesChecksum -ArchivePath $archivePath -ChecksumsPath $checksumsPath -AssetName $assetName
+
+        if ($IsWindows) {
+            Expand-Archive -Path $archivePath -DestinationPath $installRoot -Force
+            $syftExecutablePath = Join-Path $installRoot 'syft.exe'
+        }
+        else {
+            Invoke-CommandChecked -ExecutablePath 'tar' -Arguments @('-xzf', $archivePath, '-C', $installRoot)
+            $syftExecutablePath = Join-Path $installRoot 'syft'
+        }
+
+        if (-not (Test-Path -LiteralPath $syftExecutablePath)) {
+            throw "Syft executable was not found after extraction: $syftExecutablePath"
+        }
+
+        $downloadedVersion = Get-SyftVersion -ExecutablePath $syftExecutablePath
+        if ($downloadedVersion -ne $versionWithoutPrefix) {
+            throw "Downloaded Syft version '$downloadedVersion' does not match requested version '$RequestedSyftVersion'."
+        }
+
+        return $syftExecutablePath
     }
+    finally {
+        if (Test-Path -LiteralPath $archivePath) {
+            Remove-Item -LiteralPath $archivePath -Force
+        }
 
-    New-Item -ItemType Directory -Path $installRoot | Out-Null
-    Write-Host "Downloading Syft $RequestedSyftVersion from $downloadUrl"
-    Invoke-WebRequest -Uri $downloadUrl -OutFile $archivePath
-
-    if ($IsWindows) {
-        Expand-Archive -Path $archivePath -DestinationPath $installRoot -Force
-        $syftExecutablePath = Join-Path $installRoot 'syft.exe'
+        if (Test-Path -LiteralPath $checksumsPath) {
+            Remove-Item -LiteralPath $checksumsPath -Force
+        }
     }
-    else {
-        Invoke-CommandChecked -ExecutablePath 'tar' -Arguments @('-xzf', $archivePath, '-C', $installRoot)
-        $syftExecutablePath = Join-Path $installRoot 'syft'
-    }
-
-    if (-not (Test-Path -LiteralPath $syftExecutablePath)) {
-        throw "Syft executable was not found after extraction: $syftExecutablePath"
-    }
-
-    return $syftExecutablePath
 }
 
 function Get-PackageFile {

--- a/scripts/Invoke-PackWithSbom.ps1
+++ b/scripts/Invoke-PackWithSbom.ps1
@@ -1,0 +1,208 @@
+param(
+    [string]$ProjectPath = 'src/DependencyContractAnalyzer/DependencyContractAnalyzer.csproj',
+    [string]$Configuration = 'Release',
+    [string]$OutputDirectory = 'artifacts',
+    [string[]]$AdditionalDotNetPackArguments = @(),
+    [string]$SyftPath = 'syft',
+    [string]$SyftVersion,
+    [switch]$DownloadSyftIfMissing
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+Add-Type -AssemblyName System.IO.Compression.FileSystem
+
+$script:EmbeddedSbomFileName = 'sbom.cdx.json'
+
+function Resolve-AbsolutePath {
+    param(
+        [string]$Path
+    )
+
+    return [System.IO.Path]::GetFullPath((Join-Path (Get-Location) $Path))
+}
+
+function Invoke-CommandChecked {
+    param(
+        [string]$ExecutablePath,
+        [string[]]$Arguments
+    )
+
+    Write-Host ($ExecutablePath + ' ' + ($Arguments -join ' '))
+    & $ExecutablePath @Arguments
+    if ($LASTEXITCODE -ne 0) {
+        throw "Command failed: $ExecutablePath $($Arguments -join ' ')"
+    }
+}
+
+function Get-SyftDownloadAssetName {
+    param(
+        [string]$VersionWithoutPrefix
+    )
+
+    if ($IsWindows) {
+        return "syft_${VersionWithoutPrefix}_windows_amd64.zip"
+    }
+
+    if ($IsLinux) {
+        return "syft_${VersionWithoutPrefix}_linux_amd64.tar.gz"
+    }
+
+    if ($IsMacOS) {
+        return "syft_${VersionWithoutPrefix}_darwin_amd64.tar.gz"
+    }
+
+    throw 'Syft auto-download is not supported on this operating system.'
+}
+
+function Install-SyftIfNeeded {
+    param(
+        [string]$RequestedSyftPath,
+        [string]$RequestedSyftVersion,
+        [switch]$AllowDownload
+    )
+
+    $resolvedCommand = Get-Command $RequestedSyftPath -ErrorAction SilentlyContinue
+    if ($null -ne $resolvedCommand) {
+        return $resolvedCommand.Source
+    }
+
+    if (-not $AllowDownload.IsPresent) {
+        throw "Syft executable '$RequestedSyftPath' was not found on PATH."
+    }
+
+    if ([string]::IsNullOrWhiteSpace($RequestedSyftVersion)) {
+        throw 'A Syft version is required when DownloadSyftIfMissing is enabled.'
+    }
+
+    $versionWithoutPrefix = $RequestedSyftVersion.TrimStart('v')
+    $assetName = Get-SyftDownloadAssetName -VersionWithoutPrefix $versionWithoutPrefix
+    $downloadUrl = "https://github.com/anchore/syft/releases/download/$RequestedSyftVersion/$assetName"
+    $installRoot = Join-Path ([System.IO.Path]::GetTempPath()) "dca-syft-$versionWithoutPrefix"
+    $archivePath = Join-Path ([System.IO.Path]::GetTempPath()) $assetName
+
+    if (Test-Path -LiteralPath $installRoot) {
+        Remove-Item -LiteralPath $installRoot -Recurse -Force
+    }
+
+    New-Item -ItemType Directory -Path $installRoot | Out-Null
+    Write-Host "Downloading Syft $RequestedSyftVersion from $downloadUrl"
+    Invoke-WebRequest -Uri $downloadUrl -OutFile $archivePath
+
+    if ($IsWindows) {
+        Expand-Archive -Path $archivePath -DestinationPath $installRoot -Force
+        $syftExecutablePath = Join-Path $installRoot 'syft.exe'
+    }
+    else {
+        Invoke-CommandChecked -ExecutablePath 'tar' -Arguments @('-xzf', $archivePath, '-C', $installRoot)
+        $syftExecutablePath = Join-Path $installRoot 'syft'
+    }
+
+    if (-not (Test-Path -LiteralPath $syftExecutablePath)) {
+        throw "Syft executable was not found after extraction: $syftExecutablePath"
+    }
+
+    return $syftExecutablePath
+}
+
+function Get-PackageFile {
+    param(
+        [string]$PackageOutputDirectory
+    )
+
+    $packageFiles = @(
+        Get-ChildItem -Path $PackageOutputDirectory -Filter 'DependencyContractAnalyzer.*.nupkg' -File
+    )
+
+    if ($packageFiles.Count -eq 0) {
+        throw "No packed DependencyContractAnalyzer package was found in '$PackageOutputDirectory'."
+    }
+
+    if ($packageFiles.Count -gt 1) {
+        $packageList = $packageFiles | ForEach-Object { $_.Name } | Sort-Object
+        throw "Expected exactly one packed DependencyContractAnalyzer package in '$PackageOutputDirectory', but found multiple:`n$($packageList -join [System.Environment]::NewLine)"
+    }
+
+    return $packageFiles[0]
+}
+
+function Add-SbomToPackage {
+    param(
+        [System.IO.FileInfo]$PackageFile,
+        [string]$ResolvedSyftPath
+    )
+
+    $workingRoot = Join-Path ([System.IO.Path]::GetTempPath()) ('dca-sbom-' + [System.Guid]::NewGuid().ToString('N'))
+    $extractRoot = Join-Path $workingRoot 'package'
+    $sbomWorkingPath = Join-Path $workingRoot $script:EmbeddedSbomFileName
+    $repackedArchivePath = Join-Path $workingRoot 'repacked.zip'
+
+    try {
+        New-Item -ItemType Directory -Path $extractRoot -Force | Out-Null
+        [System.IO.Compression.ZipFile]::ExtractToDirectory($PackageFile.FullName, $extractRoot)
+
+        if ($PackageFile.Name -notmatch '^(?<PackageId>DependencyContractAnalyzer)\.(?<PackageVersion>.+)\.nupkg$') {
+            throw "Failed to determine the package identity from '$($PackageFile.Name)'."
+        }
+
+        $packageId = $Matches['PackageId']
+        $packageVersion = $Matches['PackageVersion']
+
+        Invoke-CommandChecked -ExecutablePath $ResolvedSyftPath -Arguments @(
+            'scan',
+            "dir:$extractRoot",
+            '--source-name',
+            $packageId,
+            '--source-version',
+            $packageVersion,
+            '-o',
+            "cyclonedx-json=$sbomWorkingPath"
+        )
+
+        if (-not (Test-Path -LiteralPath $sbomWorkingPath)) {
+            throw "Syft did not generate an SBOM file at '$sbomWorkingPath'."
+        }
+
+        Move-Item -LiteralPath $sbomWorkingPath -Destination (Join-Path $extractRoot $script:EmbeddedSbomFileName)
+
+        if (Test-Path -LiteralPath $repackedArchivePath) {
+            Remove-Item -LiteralPath $repackedArchivePath -Force
+        }
+
+        [System.IO.Compression.ZipFile]::CreateFromDirectory(
+            $extractRoot,
+            $repackedArchivePath,
+            [System.IO.Compression.CompressionLevel]::Optimal,
+            $false)
+
+        Move-Item -LiteralPath $repackedArchivePath -Destination $PackageFile.FullName -Force
+    }
+    finally {
+        if (Test-Path -LiteralPath $workingRoot) {
+            Remove-Item -LiteralPath $workingRoot -Recurse -Force
+        }
+    }
+}
+
+$resolvedProjectPath = Resolve-AbsolutePath -Path $ProjectPath
+$resolvedOutputDirectory = Resolve-AbsolutePath -Path $OutputDirectory
+$resolvedSyftPath = Install-SyftIfNeeded -RequestedSyftPath $SyftPath -RequestedSyftVersion $SyftVersion -AllowDownload:$DownloadSyftIfMissing
+
+if (-not (Test-Path -LiteralPath $resolvedOutputDirectory)) {
+    New-Item -ItemType Directory -Path $resolvedOutputDirectory | Out-Null
+}
+
+Invoke-CommandChecked -ExecutablePath 'dotnet' -Arguments @(
+    'pack',
+    $resolvedProjectPath,
+    '-c',
+    $Configuration,
+    '-o',
+    $resolvedOutputDirectory
+) + $AdditionalDotNetPackArguments
+
+$packageFile = Get-PackageFile -PackageOutputDirectory $resolvedOutputDirectory
+Add-SbomToPackage -PackageFile $packageFile -ResolvedSyftPath $resolvedSyftPath
+
+Write-Host "Embedded '$script:EmbeddedSbomFileName' into '$($packageFile.FullName)'."

--- a/scripts/Invoke-PackWithSbom.ps1
+++ b/scripts/Invoke-PackWithSbom.ps1
@@ -2,7 +2,9 @@ param(
     [string]$ProjectPath = 'src/DependencyContractAnalyzer/DependencyContractAnalyzer.csproj',
     [string]$Configuration = 'Release',
     [string]$OutputDirectory = 'artifacts',
-    [string[]]$AdditionalDotNetPackArguments = @(),
+    [switch]$NoBuild,
+    [switch]$NoRestore,
+    [string[]]$PackProperties = @(),
     [string]$SyftPath = 'syft',
     [string]$SyftVersion,
     [switch]$DownloadSyftIfMissing
@@ -193,14 +195,28 @@ if (-not (Test-Path -LiteralPath $resolvedOutputDirectory)) {
     New-Item -ItemType Directory -Path $resolvedOutputDirectory | Out-Null
 }
 
-Invoke-CommandChecked -ExecutablePath 'dotnet' -Arguments @(
+$dotNetPackArguments = @(
     'pack',
     $resolvedProjectPath,
     '-c',
     $Configuration,
     '-o',
     $resolvedOutputDirectory
-) + $AdditionalDotNetPackArguments
+)
+
+if ($NoBuild.IsPresent) {
+    $dotNetPackArguments += '--no-build'
+}
+
+if ($NoRestore.IsPresent) {
+    $dotNetPackArguments += '--no-restore'
+}
+
+foreach ($packProperty in $PackProperties) {
+    $dotNetPackArguments += "-p:$packProperty"
+}
+
+Invoke-CommandChecked -ExecutablePath 'dotnet' -Arguments $dotNetPackArguments
 
 $packageFile = Get-PackageFile -PackageOutputDirectory $resolvedOutputDirectory
 Add-SbomToPackage -PackageFile $packageFile -ResolvedSyftPath $resolvedSyftPath

--- a/scripts/Test-PackedPackageConsumption.ps1
+++ b/scripts/Test-PackedPackageConsumption.ps1
@@ -6,6 +6,10 @@ param(
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
+Add-Type -AssemblyName System.IO.Compression.FileSystem
+
+$script:EmbeddedSbomFileName = 'sbom.cdx.json'
+
 if ([string]::IsNullOrWhiteSpace($PackageDirectory)) {
     $PackageDirectory = Join-Path (Join-Path $PSScriptRoot '..') 'artifacts'
 }
@@ -290,6 +294,39 @@ function Assert-FileContains {
     }
 }
 
+function Assert-PackageContainsEmbeddedSbom {
+    param(
+        [System.IO.FileInfo]$PackageFile
+    )
+
+    $archive = [System.IO.Compression.ZipFile]::OpenRead($PackageFile.FullName)
+    try {
+        $sbomEntry = $archive.Entries |
+            Where-Object { $_.FullName -eq $script:EmbeddedSbomFileName } |
+            Select-Object -First 1
+
+        if ($null -eq $sbomEntry) {
+            throw "Expected packed package '$($PackageFile.FullName)' to contain '$script:EmbeddedSbomFileName'."
+        }
+
+        $reader = New-Object System.IO.StreamReader($sbomEntry.Open())
+        try {
+            $sbomContent = $reader.ReadToEnd()
+        }
+        finally {
+            $reader.Dispose()
+        }
+
+        if ($sbomContent.IndexOf('"bomFormat":"CycloneDX"', [System.StringComparison]::OrdinalIgnoreCase) -lt 0 -and
+            $sbomContent.IndexOf('"bomFormat": "CycloneDX"', [System.StringComparison]::OrdinalIgnoreCase) -lt 0) {
+            throw "Expected '$script:EmbeddedSbomFileName' in '$($PackageFile.FullName)' to be a CycloneDX document."
+        }
+    }
+    finally {
+        $archive.Dispose()
+    }
+}
+
 function Get-InstalledSdkVersionForMajor {
     param(
         [int]$MajorVersion
@@ -323,6 +360,7 @@ $packageFile = Get-LatestPackageFile -PackageDirectoryPath $packageDirectoryPath
 $packageVersion = Get-PackageVersion -PackageFile $packageFile
 
 Write-Host "Using packed package '$($packageFile.FullName)'."
+Assert-PackageContainsEmbeddedSbom -PackageFile $packageFile
 
 # Keep the smoke project outside the repo so repository-wide MSBuild props do not affect the package test.
 $workingRoot = Join-Path ([System.IO.Path]::GetTempPath()) ('dca-packed-package-smoke-' + [System.Guid]::NewGuid().ToString('N'))

--- a/scripts/Validate-CiWorkflow.ps1
+++ b/scripts/Validate-CiWorkflow.ps1
@@ -8,7 +8,8 @@ $requiredFragments = [ordered]@{
     'build validation command' = 'run: dotnet build DependencyContractAnalyzer.slnx -c Release --no-restore'
     'test validation command' = 'run: dotnet test DependencyContractAnalyzer.slnx -c Release --no-restore --collect "XPlat Code Coverage" --results-directory artifacts/test-results'
     'analyzer validation command' = 'run: dotnet build DependencyContractAnalyzer.slnx -c Release --no-restore -warnaserror'
-    'pack validation command' = 'run: dotnet pack src/DependencyContractAnalyzer/DependencyContractAnalyzer.csproj -c Release --no-restore -o artifacts'
+    'Syft version environment' = 'SYFT_VERSION: v1.42.3'
+    'pack validation command' = 'run: ./scripts/Invoke-PackWithSbom.ps1 -ProjectPath src/DependencyContractAnalyzer/DependencyContractAnalyzer.csproj -Configuration Release -OutputDirectory artifacts -AdditionalDotNetPackArguments ''--no-restore'' -SyftVersion ${{ env.SYFT_VERSION }} -DownloadSyftIfMissing'
     'release PR changelog validation step name' = '- name: Validate release PR changelog advancement'
     'release PR changelog validation condition' = "if: github.event_name == 'pull_request' && github.base_ref == 'main'"
     'release PR changelog validation command' = 'run: ./scripts/Validate-ReleasePrChangelog.ps1'

--- a/scripts/Validate-CiWorkflow.ps1
+++ b/scripts/Validate-CiWorkflow.ps1
@@ -9,7 +9,7 @@ $requiredFragments = [ordered]@{
     'test validation command' = 'run: dotnet test DependencyContractAnalyzer.slnx -c Release --no-restore --collect "XPlat Code Coverage" --results-directory artifacts/test-results'
     'analyzer validation command' = 'run: dotnet build DependencyContractAnalyzer.slnx -c Release --no-restore -warnaserror'
     'Syft version environment' = 'SYFT_VERSION: v1.42.3'
-    'pack validation command' = 'run: ./scripts/Invoke-PackWithSbom.ps1 -ProjectPath src/DependencyContractAnalyzer/DependencyContractAnalyzer.csproj -Configuration Release -OutputDirectory artifacts -AdditionalDotNetPackArguments ''--no-restore'' -SyftVersion ${{ env.SYFT_VERSION }} -DownloadSyftIfMissing'
+    'pack validation command' = 'run: ./scripts/Invoke-PackWithSbom.ps1 -ProjectPath src/DependencyContractAnalyzer/DependencyContractAnalyzer.csproj -Configuration Release -OutputDirectory artifacts -NoRestore -SyftVersion ${{ env.SYFT_VERSION }} -DownloadSyftIfMissing'
     'release PR changelog validation step name' = '- name: Validate release PR changelog advancement'
     'release PR changelog validation condition' = "if: github.event_name == 'pull_request' && github.base_ref == 'main'"
     'release PR changelog validation command' = 'run: ./scripts/Validate-ReleasePrChangelog.ps1'

--- a/scripts/Validate-PublishWorkflow.ps1
+++ b/scripts/Validate-PublishWorkflow.ps1
@@ -8,6 +8,8 @@ $requiredFragments = [ordered]@{
     'contents write permission' = 'contents: write'
     'NuGet.org package routing' = 'package_source=https://www.nuget.org/api/v2/package'
     'int.nugettest.org package routing' = 'package_source=https://int.nugettest.org/api/v2/package'
+    'Syft version environment' = 'SYFT_VERSION: v1.42.3'
+    'pack with SBOM command' = 'run: ./scripts/Invoke-PackWithSbom.ps1 -ProjectPath src/DependencyContractAnalyzer/DependencyContractAnalyzer.csproj -Configuration Release -OutputDirectory artifacts -AdditionalDotNetPackArguments ''--no-build'', ''-p:RelaxVersionerCheckWorkingDirectoryStatus=false'' -SyftVersion ${{ env.SYFT_VERSION }} -DownloadSyftIfMissing'
     'release notes step name' = '- name: Prepare GitHub Release notes'
     'release notes step id' = 'id: github_release_notes'
     'release step name' = '- name: Create or update GitHub Release'

--- a/scripts/Validate-PublishWorkflow.ps1
+++ b/scripts/Validate-PublishWorkflow.ps1
@@ -9,7 +9,7 @@ $requiredFragments = [ordered]@{
     'NuGet.org package routing' = 'package_source=https://www.nuget.org/api/v2/package'
     'int.nugettest.org package routing' = 'package_source=https://int.nugettest.org/api/v2/package'
     'Syft version environment' = 'SYFT_VERSION: v1.42.3'
-    'pack with SBOM command' = 'run: ./scripts/Invoke-PackWithSbom.ps1 -ProjectPath src/DependencyContractAnalyzer/DependencyContractAnalyzer.csproj -Configuration Release -OutputDirectory artifacts -AdditionalDotNetPackArguments ''--no-build'', ''-p:RelaxVersionerCheckWorkingDirectoryStatus=false'' -SyftVersion ${{ env.SYFT_VERSION }} -DownloadSyftIfMissing'
+    'pack with SBOM command' = 'run: ./scripts/Invoke-PackWithSbom.ps1 -ProjectPath src/DependencyContractAnalyzer/DependencyContractAnalyzer.csproj -Configuration Release -OutputDirectory artifacts -NoBuild -PackProperties ''RelaxVersionerCheckWorkingDirectoryStatus=false'' -SyftVersion ${{ env.SYFT_VERSION }} -DownloadSyftIfMissing'
     'release notes step name' = '- name: Prepare GitHub Release notes'
     'release notes step id' = 'id: github_release_notes'
     'release step name' = '- name: Create or update GitHub Release'

--- a/src/DependencyContractAnalyzer/DependencyContractAnalyzer.csproj
+++ b/src/DependencyContractAnalyzer/DependencyContractAnalyzer.csproj
@@ -32,6 +32,7 @@
   <ItemGroup>
     <None Include="..\..\README.md" Pack="true" PackagePath="\" Visible="false" />
     <None Include="..\..\LICENSE" Pack="true" PackagePath="\" Visible="false" />
+    <None Include="..\..\THIRD-PARTY-NOTICES.md" Pack="true" PackagePath="\" Visible="false" />
     <None Include="..\..\assets\package-icon.png" Pack="true" PackagePath="\" Visible="false" />
     <None Include="Attributes\ContractHierarchyAttribute.cs" Pack="true" PackagePath="build\DependencyContractAnalyzer.Attributes\ContractHierarchyAttribute.cs" Visible="false" />
     <None Include="Attributes\ContractScopeAttribute.cs" Pack="true" PackagePath="build\DependencyContractAnalyzer.Attributes\ContractScopeAttribute.cs" Visible="false" />


### PR DESCRIPTION
## Summary
- release `1.2.0`
- embed a Syft-generated CycloneDX SBOM as `sbom.cdx.json` in the distributed `.nupkg`
- fix publish pack version handling so tagged releases preserve the exact tag version
- update release and development documentation for the SBOM packaging flow

## Validation
- `pwsh -NoProfile -File ./scripts/Validate-CiWorkflow.ps1`
- `pwsh -NoProfile -File ./scripts/Validate-PublishWorkflow.ps1`
- `pwsh -NoProfile -File ./scripts/Invoke-PackWithSbom.ps1 -ProjectPath src/DependencyContractAnalyzer/DependencyContractAnalyzer.csproj -Configuration Release -OutputDirectory artifacts/sbom-check -SyftVersion v1.42.3 -DownloadSyftIfMissing`
- `pwsh -NoProfile -File ./scripts/Test-PackedPackageConsumption.ps1 -PackageDirectory artifacts/sbom-check`
- `pwsh -NoProfile -File ./scripts/Invoke-PackWithSbom.ps1 -ProjectPath src/DependencyContractAnalyzer/DependencyContractAnalyzer.csproj -Configuration Release -OutputDirectory artifacts/ci-fix-check2 -NoBuild -PackProperties RelaxVersionerCheckWorkingDirectoryStatus=false -SyftVersion v1.42.3 -DownloadSyftIfMissing`
- `pwsh -NoProfile -File ./scripts/Test-PackedPackageConsumption.ps1 -PackageDirectory artifacts/ci-fix-check2`
