### PR TITLE
ci: relax release PR changelog requirement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,11 +29,6 @@ jobs:
         shell: pwsh
         run: ./scripts/Validate-PublishWorkflow.ps1
 
-      - name: Validate release PR changelog advancement
-        if: github.event_name == 'pull_request' && github.base_ref == 'main'
-        shell: pwsh
-        run: ./scripts/Validate-ReleasePrChangelog.ps1
-
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@v5
         with:

--- a/scripts/Validate-CiWorkflow.ps1
+++ b/scripts/Validate-CiWorkflow.ps1
@@ -10,9 +10,6 @@ $requiredFragments = [ordered]@{
     'analyzer validation command' = 'run: dotnet build DependencyContractAnalyzer.slnx -c Release --no-restore -warnaserror'
     'Syft version environment' = 'SYFT_VERSION: v1.42.3'
     'pack validation command' = 'run: ./scripts/Invoke-PackWithSbom.ps1 -ProjectPath src/DependencyContractAnalyzer/DependencyContractAnalyzer.csproj -Configuration Release -OutputDirectory artifacts -NoRestore -SyftVersion ${{ env.SYFT_VERSION }} -DownloadSyftIfMissing'
-    'release PR changelog validation step name' = '- name: Validate release PR changelog advancement'
-    'release PR changelog validation condition' = "if: github.event_name == 'pull_request' && github.base_ref == 'main'"
-    'release PR changelog validation command' = 'run: ./scripts/Validate-ReleasePrChangelog.ps1'
 }
 
 foreach ($requiredFragment in $requiredFragments.GetEnumerator()) {


### PR DESCRIPTION
## Summary
- remove the release PR changelog advancement check from CI
- stop enforcing that invariant in the CI workflow validation script
- keep the standalone validation script in the repository for possible future use

## Why
Release PRs to `main` can include README or other non-release documentation updates. Those changes should not be forced to add a new version section to `CHANGELOG.md`.

## Testing
- ran `pwsh -NoProfile -File ./scripts/Validate-CiWorkflow.ps1`

## Tracking
- refs #154